### PR TITLE
Додано домени WOT Blitz

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - `cloud_storage.txt` — хмарні сховища (Google Drive, MEGA, Synology тощо);
 - `messengers.txt` — домени Telegram, WhatsApp, Discord;
 - `ntp_servers.txt` — сервери точного часу (NTP).
+- `gaming.txt` — домени для ігор, зокрема World of Tanks Blitz.
 
 ## Генерація загального списку
 

--- a/categories/gaming.txt
+++ b/categories/gaming.txt
@@ -1,0 +1,7 @@
+# Ігри та онлайн-сервіси
+wotblitz.com          # офіційний сайт WOT Blitz
+wotblitz.eu           # європейський портал
+wargaming.net         # головний домен компанії
+login.wargaming.net   # авторизація
+cdn.wargaming.net     # CDN з оновленнями
+wgcdn.co              # додатковий CDN

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -223,3 +223,12 @@ ua.pool.ntp.org           # український пул NTP
 time.nist.gov             # сервер точного часу NIST
 time.facebook.com        # сервер часу Facebook
 time.is                  # сервіс перевірки часу
+
+# World of Tanks Blitz
+wotblitz.com          # офіційний сайт гри
+wotblitz.eu           # європейський портал
+wargaming.net         # головний домен компанії
+login.wargaming.net   # авторизація
+cdn.wargaming.net     # CDN з оновленнями
+wgcdn.co              # додатковий CDN
+


### PR DESCRIPTION
## Опис
- новий список `gaming.txt` з доменами World of Tanks Blitz
- оновлено `whitelist.txt`: додані ті ж домени
- README тепер містить опис нового файлу категорій

## Тестування
- `./check_duplicates.sh categories/gaming.txt`
- `./check_duplicates.sh whitelist.txt`


------
https://chatgpt.com/codex/tasks/task_e_68848ee6116c832eaff31f39db2760bf