### PR TITLE
Додано список CDN для скриптів та стилів

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - `messengers.txt` — домени Telegram, WhatsApp, Discord;
 - `ntp_servers.txt` — сервери точного часу (NTP).
 - `gaming.txt` — домени для ігор, зокрема World of Tanks Blitz.
+- `web_resources.txt` — CDN та хости скриптів і стилів для вигляду сайтів.
 
 ## Генерація загального списку
 

--- a/categories/web_resources.txt
+++ b/categories/web_resources.txt
@@ -1,0 +1,8 @@
+# Веб-ресурси для скриптів та стилів
+fonts.googleapis.com    # стилі Google Fonts
+fonts.gstatic.com       # шрифти Google Fonts
+ajax.googleapis.com     # бібліотеки jQuery та інші
+code.jquery.com         # CDN jQuery
+cdnjs.cloudflare.com    # популярний CDN з бібліотеками JS
+cdn.jsdelivr.net        # CDN jsDelivr для скриптів та стилів
+unpkg.com               # CDN npm-пакунків

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -232,3 +232,12 @@ login.wargaming.net   # авторизація
 cdn.wargaming.net     # CDN з оновленнями
 wgcdn.co              # додатковий CDN
 
+
+# Веб-ресурси для скриптів та стилів
+fonts.googleapis.com    # стилі Google Fonts
+fonts.gstatic.com       # шрифти Google Fonts
+ajax.googleapis.com     # бібліотеки jQuery та інші
+code.jquery.com         # CDN jQuery
+cdnjs.cloudflare.com    # популярний CDN з бібліотеками JS
+cdn.jsdelivr.net        # CDN jsDelivr для скриптів та стилів
+unpkg.com               # CDN npm-пакунків


### PR DESCRIPTION
## Зміни
- новий файл `categories/web_resources.txt` з доменами популярних CDN
- оновлено README: додано опис нового списку
- розширено `whitelist.txt` відповідними доменами

## Тестування
- `./check_duplicates.sh categories/web_resources.txt`
- `./check_duplicates.sh whitelist.txt`


------
https://chatgpt.com/codex/tasks/task_e_688490aea324832e8625491e5c0ccd29