### PR TITLE
Update whitelist domains for Max and X

### DIFF
--- a/categories/social_networks.txt
+++ b/categories/social_networks.txt
@@ -2,6 +2,7 @@
 facebook.com
 instagram.com
 twitter.com
+x.com               # X (колишній Twitter)
 linkedin.com
 tiktok.com
 snapchat.com

--- a/categories/streaming_services.txt
+++ b/categories/streaming_services.txt
@@ -3,7 +3,8 @@ netflix.com
 disneyplus.com
 hulu.com
 primevideo.com
-hbomax.com
+hbomax.com            # старий домен HBO Max
+max.com               # сервіс Max (раніше HBO Max)
 spotify.com
 soundcloud.com
 deezer.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -233,7 +233,7 @@ gsp1.apple.com
 gsra.apple.com
 gstaticadssl.l.google.com
 guzzoni.apple.com
-hbomax.com
+hbomax.com            # старий домен HBO Max
 help.ui.xboxlive.com
 hoyoverse.com          # ігри HoYoverse (Genshin Impact)
 huggingface.co           # платформа HuggingFace
@@ -279,6 +279,7 @@ login.wargaming.net   # авторизація
 login.windows.net
 m.hotmail.com
 malwarebytes.com
+max.com               # сервіс Max (раніше HBO Max)
 mcafee.com
 mdmenrollment.apple.com
 mega.co.nz                      # старий домен MEGA
@@ -543,6 +544,7 @@ www.redditstatic.com
 www.signal.org
 www.synology.com          # веб-інтерфейс
 www.xboxlive.com
+x.com               # X (колишній Twitter)
 xbox.com               # офіційний сайт Xbox
 xbox.ipv6.microsoft.com
 xboxexperiencesprod.experimentation.xboxlive.com


### PR DESCRIPTION
## Summary
- додано новий домен `max.com` для сервісу Max (заміна HBO Max)
- оновлено список соцмереж: додано `x.com` як новий домен X (колишній Twitter)
- перегенеровано зведений `whitelist.txt`

## Testing
- `./check_duplicates.sh categories/streaming_services.txt categories/social_networks.txt`


------
https://chatgpt.com/codex/tasks/task_e_688627e59f18832ea46dbbea8169ce64