### PR TITLE
Додати googletagmanager.com до білого списку

### DIFF
--- a/categories/web_resources.txt
+++ b/categories/web_resources.txt
@@ -8,4 +8,5 @@ cdn.jsdelivr.net        # CDN jsDelivr для скриптів та стилів
 unpkg.com               # CDN npm-пакунків
 assets.adobe.com          # хмарні ресурси Adobe
 use.fontawesome.com       # іконки FontAwesome
+googletagmanager.com       # менеджер тегів Google
 static.cloudflareinsights.com # аналітика Cloudflare Insights

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -223,6 +223,7 @@ go.microsoft.com
 gog.com                # магазин GOG
 google.com        # пошукова система
 googleapis.l.google.com
+googletagmanager.com       # менеджер тегів Google
 graph.facebook.com
 graph.microsoft.com
 gs.apple.com


### PR DESCRIPTION
## Опис
- додано домен `googletagmanager.com` до категорії веб-ресурсів
- згенеровано оновлений `whitelist.txt`

## Тестування
- `./generate_whitelist.sh`
- `./check_duplicates.sh categories/web_resources.txt` (доступність доменів не підтверджена)


------
https://chatgpt.com/codex/tasks/task_e_689201820b50832e9ae2d8d36bdfba11