### PR TITLE
Додати скрипт застосування білого списку для Pi-hole

### DIFF
--- a/apply_whitelist.sh
+++ b/apply_whitelist.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Скрипт додає домени з whitelist.txt до білого списку Pi-hole.
+# Коментарі й порожні рядки ігноруються.
+# Використання: ./apply_whitelist.sh [шлях_до_файла]
+set -euo pipefail
+
+FILE="${1:-whitelist.txt}"
+
+if [ ! -f "$FILE" ]; then
+  echo "Файл $FILE не знайдено" >&2
+  exit 1
+fi
+
+if ! command -v pihole >/dev/null 2>&1; then
+  echo "Команду pihole не знайдено" >&2
+  exit 1
+fi
+
+grep -v '^\s*#' "$FILE" | sed '/^\s*$/d' | while read -r domain; do
+  pihole -w "$domain"
+done
+
+echo "Доменів з $FILE додано до білого списку"

--- a/tests/apply_whitelist_test.sh
+++ b/tests/apply_whitelist_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+export PIHOLE_CALLS_LOG="$tmpdir/calls.log"
+
+cat <<'MOCK' > "$tmpdir/pihole"
+#!/usr/bin/env bash
+echo "$@" >> "$PIHOLE_CALLS_LOG"
+MOCK
+chmod +x "$tmpdir/pihole"
+
+export PATH="$tmpdir:$PATH"
+
+cat <<'LIST' > "$tmpdir/whitelist.txt"
+# коментар
+example.com
+
+test.org
+LIST
+
+./apply_whitelist.sh "$tmpdir/whitelist.txt" >/dev/null
+
+grep -Fxq -- "-w example.com" "$PIHOLE_CALLS_LOG"
+grep -Fxq -- "-w test.org" "$PIHOLE_CALLS_LOG"
+
+echo "Тест apply_whitelist.sh пройдено"


### PR DESCRIPTION
## Summary
- Додано скрипт apply_whitelist.sh для автоматичного застосування білого списку через `pihole -w`.
- Створено інтеграційний тест, що імітує виклики `pihole`.

## Testing
- `shellcheck apply_whitelist.sh tests/apply_whitelist_test.sh`
- `bash tests/apply_whitelist_test.sh`
- `bash tests/generate_whitelist_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689957288524832eb4a2bfa5d4f8fdee