### PR TITLE
Перевірка дублікатів за доменом без урахування коментарів

### DIFF
--- a/check_duplicates.sh
+++ b/check_duplicates.sh
@@ -11,7 +11,13 @@ check_file() {
   fi
 
   local dup
-  dup=$(grep -v '^\s*#' "$file" | sed '/^\s*$/d' | sort | uniq -d)
+  # Видаляємо коментарі, щоб дублікати шукалися лише за доменами
+  dup=$(grep -v '^\s*#' "$file" \
+    | sed '/^\s*$/d' \
+    | cut -d '#' -f1 \
+    | awk '{print $1}' \
+    | sort \
+    | uniq -d)
   if [ -n "$dup" ]; then
     echo "Знайдені дублікати у $file:" >&2
     echo "$dup"


### PR DESCRIPTION
## Зміни
- під час пошуку дублікатів у check_duplicates.sh коментарі обрізаються, тому перевірка здійснюється лише за доменами

## Тестування
- `bash tests/apply_whitelist_test.sh`
- `bash tests/cleanup_whitelist_test.sh`
- `bash tests/generate_whitelist_test.sh`

Відсутні юніт-тести для check_duplicates.sh — варто додати окремий тест.

------
https://chatgpt.com/codex/tasks/task_e_6899668a2b08832eaf6798265d46a524