### PR TITLE
Додано домени сервісу Eyecon

### DIFF
--- a/categories/messengers.txt
+++ b/categories/messengers.txt
@@ -5,3 +5,5 @@ core.telegram.org          # документація Telegram
 discord.com             # чат Discord
 telegram.org            # месенджер Telegram
 whatsapp.com            # месенджер WhatsApp
+eyecon-app.com         # телефонна книга Eyecon
+www.eyecon-app.com     # вебінтерфейс Eyecon

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -194,6 +194,7 @@ external-lhr7-1.xx.fbcdn.net
 external-lhr8-1.xx.fbcdn.net
 external-lhr9-1.xx.fbcdn.net
 external-ort2-1.xx.fbcdn.net
+eyecon-app.com
 fabric.io
 facebook.com
 favorites.live.com
@@ -536,6 +537,7 @@ www.apple.com
 www.appleiphonecell.com
 www.cloudflare.com
 www.creality.com
+www.eyecon-app.com
 www.facebook.com
 www.google.com
 www.googleapis.com


### PR DESCRIPTION
## Зміни
- додано домени `eyecon-app.com` та `www.eyecon-app.com` до категорії месенджерів
- згенеровано оновлений `whitelist.txt`

## Тестування
- `./check_duplicates.sh categories/messengers.txt` *(попередження: скрипт позначив домени як недоступні, ймовірно через обмеження середовища)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7280994832eba76f7612dffc663