### PR TITLE
Додано додаткові домени Cloudflare WARP

### DIFF
--- a/categories/cloudflare_warp.txt
+++ b/categories/cloudflare_warp.txt
@@ -5,8 +5,14 @@ cf-v4.cloudflare.com
 cloudflare-dns.com
 cloudflarewarp.com
 connectivity.cloudflareclient.com
+developers.cloudflare.com
 engage.cloudflareclient.com
+help.cloudflare.com
+one.one.one.one
 security.cloudflare-dns.com
+speed.cloudflare.com
+status.cloudflare.com
+support.cloudflare.com
 teams.cloudflare.com
 update.argotunnel.com
 warp.cloudflare.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -143,6 +143,7 @@ deezer.com
 def-vef.xboxlive.com
 defs.symantec.com
 dev.virtualearth.net
+developers.cloudflare.com
 device.auth.xboxlive.com
 device.mycrealitycloud.com
 deviceenrollment.apple.com
@@ -234,6 +235,7 @@ gsra.apple.com
 gstaticadssl.l.google.com
 guzzoni.apple.com
 hbomax.com
+help.cloudflare.com
 help.ui.xboxlive.com
 hoyoverse.com
 huggingface.co
@@ -323,6 +325,7 @@ office365.com
 officecdn.microsoft.com
 officeclient.microsoft.com
 olx.ua
+one.one.one.one
 oneclient.sfx.ms
 onedrive.com
 onedrive.live.com
@@ -416,6 +419,7 @@ sophosupd.com
 soundcloud.com
 souqcdn.com
 spclient.wg.spotify.com
+speed.cloudflare.com
 spending.gov.ua
 spoprod-a.akamaihd.net
 spotify.com
@@ -428,6 +432,7 @@ static.creality.com
 static.ips.apple.com
 static.monobank.ua
 static.xx.fbcdn.net
+status.cloudflare.com
 status.github.com
 steam-chat.com
 steamcommunity.com
@@ -442,6 +447,7 @@ stripe.com
 styles.redditmedia.com
 suconfig.apple.com
 support.apple.com
+support.cloudflare.com
 supportmetrics.apple.com
 suspilne.media
 swcdn.apple.com


### PR DESCRIPTION
## Опис
- розширено список `cloudflare_warp` новими доменами Cloudflare
- згенеровано оновлений `whitelist.txt`

## Тестування
- `./check_duplicates.sh categories/cloudflare_warp.txt` *(помилки резолвінгу, ймовірно через середовище)*
- `./generate_whitelist.sh`
- `./check_duplicates.sh whitelist.txt` *(помилки резолвінгу, ймовірно через середовище)*

------
https://chatgpt.com/codex/tasks/task_e_68ab701ded90832ebcaa4e9dc1107c07