### PR TITLE
feat: додано домен openai.gallerycdn.vsassets.io

### DIFF
--- a/categories/web_resources.txt
+++ b/categories/web_resources.txt
@@ -7,6 +7,7 @@ code.jquery.com         # CDN jQuery
 fonts.googleapis.com    # стилі Google Fonts
 fonts.gstatic.com       # шрифти Google Fonts
 googletagmanager.com       # менеджер тегів Google
+openai.gallerycdn.vsassets.io # ресурси OpenAI для VS Code
 static.cloudflareinsights.com # аналітика Cloudflare Insights
 unpkg.com               # CDN npm-пакунків
 use.fontawesome.com       # іконки FontAwesome

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -330,6 +330,7 @@ oneclient.sfx.ms
 onedrive.com
 onedrive.live.com
 openai.com
+openai.gallerycdn.vsassets.io
 oscdn.apple.com
 oschadbank.ua
 osrecovery.apple.com


### PR DESCRIPTION
## Summary
- додано домен `openai.gallerycdn.vsassets.io` до категорії веб-ресурсів
- згенеровано оновлений `whitelist.txt`

## Testing
- `./generate_whitelist.sh`
- `./check_duplicates.sh` *(попередження: більшість доменів позначені як недоступні, імовірно через обмеження середовища)*

------
https://chatgpt.com/codex/tasks/task_e_68b47b983210832e80ec483b81fe0d7e