### PR TITLE
Додано freepik.com до білого списку

### DIFF
--- a/categories/web_resources.txt
+++ b/categories/web_resources.txt
@@ -6,6 +6,7 @@ cdnjs.cloudflare.com    # популярний CDN з бібліотеками J
 code.jquery.com         # CDN jQuery
 fonts.googleapis.com    # стилі Google Fonts
 fonts.gstatic.com       # шрифти Google Fonts
+freepik.com         # стокові зображення та векторна графіка
 googletagmanager.com       # менеджер тегів Google
 openai.gallerycdn.vsassets.io # ресурси OpenAI для VS Code
 static.cloudflareinsights.com # аналітика Cloudflare Insights

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -208,6 +208,7 @@ fe3.delivery.dsp.mp.microsoft.com.nsatc.net
 firestore.googleapis.com
 fonts.googleapis.com
 fonts.gstatic.com
+freepik.com
 g.live.com
 gdlp01.c-wss.com
 gdmf-ados.apple.com


### PR DESCRIPTION
## Опис
- перевірено домен `freepik.com` на наявність у фішингових списках
- додано `freepik.com` до категорії веб-ресурсів і оновлено загальний whitelist

## Тестування
- `tests/shellcheck_test.sh`
- `tests/sort_categories_test.sh`
- `tests/check_duplicates_test.sh`
- `tests/generate_whitelist_test.sh`
- `tests/apply_whitelist_test.sh`
- `tests/cleanup_whitelist_test.sh`
- `tests/update_and_apply_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b7caa6bfe4832ea3183efd715990d2