### PR TITLE
Додано додаткові домени для TikTok та Pinterest

### DIFF
--- a/categories/extended_services.txt
+++ b/categories/extended_services.txt
@@ -4,6 +4,7 @@ android.clients.google.com
 api-tv.spotify.com
 api.directory.signal.org
 api.facebook.com
+api.pinterest.com
 api.twitter.com
 appleid.apple.com
 apps.skype.com
@@ -96,6 +97,7 @@ ns2.dropbox.com
 oauthaccountmanager.googleapis.com
 officeclient.microsoft.com
 outlook.office365.com
+*.pinimg.com
 portal.fb.com
 pricelist.skype.com
 products.office.com
@@ -131,6 +133,7 @@ t0.ssl.ak.dynamic.tiles.virtualearth.net
 t0.ssl.ak.tiles.virtualearth.net
 textsecure-service-whispersystems.org
 thumbs.redditmedia.com
+tiktokapi.com
 tiktokcdn-in.com
 tiktokcdn-us.com
 tiktokcdn.com
@@ -160,6 +163,7 @@ video.xx.fbcdn.net
 wa.me
 web.facebook.com
 whispersystems-textsecure-attachments.s3-accelerate.amazonaws.com
+widgets.pinterest.com
 www.apple.com
 www.appleiphonecell.com
 www.facebook.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -19,6 +19,7 @@
 *.officeapps.live.com
 *.omtrdc.net
 *.onedrive.com
+*.pinimg.com
 *.policies.live.net
 *.servicebus.windows.net
 *.settings.live.net
@@ -53,6 +54,7 @@ api.mycrealitycloud.com
 api.novaposhta.ua
 api.openai.com
 api.paymonobank.ua
+api.pinterest.com
 api.privatbank.ua
 api.push.apple.com
 api.telegram.org
@@ -468,6 +470,7 @@ telegram.org
 textsecure-service-whispersystems.org
 thumbs.redditmedia.com
 tiktok.com
+tiktokapi.com
 tiktokcdn-in.com
 tiktokcdn-us.com
 tiktokcdn.com
@@ -539,6 +542,7 @@ wgcdn.co
 wgus.wargaming.net
 whatsapp.com
 whispersystems-textsecure-attachments.s3-accelerate.amazonaws.com
+widgets.pinterest.com
 wikipedia.org
 windowsupdate.microsoft.com
 wise.com


### PR DESCRIPTION
## Опис
- додано нові домени TikTok та Pinterest до `extended_services`
- згенеровано оновлений `whitelist.txt`

## Перевірка
- `./generate_whitelist.sh`
- `./check_duplicates.sh` (частина доменів недоступна у поточному середовищі)


------
https://chatgpt.com/codex/tasks/task_e_68b7ce2df200832e8293a6fcafb369b1