### PR TITLE
Додано відсутні домени Apple до білого списку

### DIFF
--- a/categories/apple.txt
+++ b/categories/apple.txt
@@ -1,5 +1,18 @@
 # Сервіси Apple — домени для iCloud та інфраструктури Apple
+*.appattest.apple.com
+*.apps-marketplace.apple.com
+*.apps.apple.com
+*.business.apple.com
+*.gc.apple.com
+*.icloud.apple.com
+*.itunes.apple.com
+*.iwork.apple.com
+*.push.apple.com
+*.school.apple.com
+*.smoot.apple.com
 api.apple-cloudkit.com
+api-business.apple.com
+api-school.apple.com
 appleid.apple.com
 apps.apple.com
 icloud.com


### PR DESCRIPTION
### Що зроблено
- додано 13 відсутніх wildcard-доменів Apple до категорії `apple`
- включено домени `api-business.apple.com` та `api-school.apple.com` відповідно до переліку HT210060

### Тестування
- `./tests/check_duplicates_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d0617b7150832ea8c0b0d57e7f0de7