### PR TITLE
Збереження коментарів під час перевірки та застосування білого списку

### DIFF
--- a/cleanup_whitelist.sh
+++ b/cleanup_whitelist.sh
@@ -114,7 +114,7 @@ while IFS= read -r -d '' file; do
         unset 'FAILS[$domain]'
       else
         FAILS[$domain]=$count
-        echo "$domain" >> "$tmp"
+        echo "$clean_line" >> "$tmp"
       fi
     fi
   done

--- a/tests/apply_whitelist_test.sh
+++ b/tests/apply_whitelist_test.sh
@@ -5,7 +5,8 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 echo "# коментар" > "$tmpdir/whitelist.txt"
-echo "example.com" >> "$tmpdir/whitelist.txt"
+echo "example.com # пояснення" >> "$tmpdir/whitelist.txt"
+echo "  inline.test   # зайві пробіли" >> "$tmpdir/whitelist.txt"
 echo "test.org" >> "$tmpdir/whitelist.txt"
 
 # Функція створення мок-команд
@@ -36,13 +37,17 @@ export PIHOLE_CALLS_LOG="$tmpdir/calls.log"
 create_mock 5
 ./apply_whitelist.sh "$tmpdir/whitelist.txt" >/dev/null
 grep -Fxq -- "-w example.com" "$PIHOLE_CALLS_LOG"
+grep -Fxq -- "-w inline.test" "$PIHOLE_CALLS_LOG"
 grep -Fxq -- "-w test.org" "$PIHOLE_CALLS_LOG"
+! grep -q '#' "$PIHOLE_CALLS_LOG"
 
 # Перевірка для v6
 : > "$PIHOLE_CALLS_LOG"
 create_mock 6
 ./apply_whitelist.sh "$tmpdir/whitelist.txt" >/dev/null
 grep -Fxq -- "whitelist add example.com" "$PIHOLE_CALLS_LOG"
+grep -Fxq -- "whitelist add inline.test" "$PIHOLE_CALLS_LOG"
 grep -Fxq -- "whitelist add test.org" "$PIHOLE_CALLS_LOG"
+! grep -q '#' "$PIHOLE_CALLS_LOG"
 
 echo "Тест apply_whitelist.sh пройдено"

--- a/tests/cleanup_whitelist_test.sh
+++ b/tests/cleanup_whitelist_test.sh
@@ -5,8 +5,8 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 mkdir "$tmpdir/categories"
 cat <<'LIST' > "$tmpdir/categories/test.txt"
-nonexistent.invalid
-example.com
+nonexistent.invalid # тимчасова проблема
+example.com # стабільний домен
 LIST
 
 STATE_FILE="$tmpdir/state.txt" \
@@ -15,6 +15,9 @@ THRESHOLD=2 \
 DEPRECATED_FILE="$tmpdir/categories/deprecated.txt" \
 LOG_FILE="$tmpdir/log.txt" \
 ./cleanup_whitelist.sh >/dev/null || true
+
+# Перевіряємо, що коментар збережено після першої невдалої перевірки
+grep -Fxq 'nonexistent.invalid # тимчасова проблема' "$tmpdir/categories/test.txt"
 
 # Після першого запуску домен не має бути в deprecated
 if [[ -f "$tmpdir/categories/deprecated.txt" ]] && grep -q 'nonexistent.invalid' "$tmpdir/categories/deprecated.txt"; then
@@ -30,9 +33,9 @@ LOG_FILE="$tmpdir/log.txt" \
 ./cleanup_whitelist.sh >/dev/null || true
 
 grep -q 'nonexistent.invalid' "$tmpdir/categories/deprecated.txt"
-! grep -q 'nonexistent.invalid' "$tmpdir/categories/test.txt"
+! grep -q 'nonexistent.invalid # тимчасова проблема' "$tmpdir/categories/test.txt"
 
-grep -q 'example.com' "$tmpdir/categories/test.txt"
+grep -q 'example.com # стабільний домен' "$tmpdir/categories/test.txt"
 ! grep -q 'example.com' "$tmpdir/categories/deprecated.txt"
 
 grep -q 'nonexistent.invalid' "$tmpdir/log.txt"


### PR DESCRIPTION
## Підсумок
- зберігаємо коментарі в категоріях під час повторних невдалих перевірок cleanup_whitelist.sh
- прибираємо inline-коментарі та зайві пробіли перед передаванням доменів у apply_whitelist.sh
- доповнюємо інтеграційні тести сценаріями із коментарями та перевіряємо відсутність їх у викликах Pi-hole

## Тестування
- `for t in tests/*_test.sh; do echo "Running $t"; bash "$t"; done`


------
https://chatgpt.com/codex/tasks/task_e_68d21dc71b5c832ebdd975fd6a3ab406