### PR TITLE
Додати домени застосунку Дія до білого списку

### DIFF
--- a/categories/ukrainian_services.txt
+++ b/categories/ukrainian_services.txt
@@ -19,6 +19,8 @@ ukr.net          # популярний поштовий сервіс
 acskidd.gov.ua
 ca.tax.gov.ua
 cabinet.tax.gov.ua
+app.diia.gov.ua    # вебверсія застосунку «Дія»
+diia.app          # офіційний сайт застосунку «Дія»
 diia.gov.ua
 e-data.gov.ua
 eauction.gov.ua

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -91,6 +91,7 @@ api.twitter.com
 apis.live.net
 app-api.ted.com
 app-site-association.cdn-apple.com
+app.diia.gov.ua
 appboot.netflix.com
 appldnld.apple.com
 apple-relay.apple.com
@@ -228,6 +229,7 @@ deviceenrollment.apple.com
 deviceservices-external.apple.com
 devimages-cdn.apple.com
 diagassets.apple.com
+diia.app
 diia.gov.ua
 directvapplications.hb.omtrdc.net
 directvnow.com


### PR DESCRIPTION
## Зміни
- додано окремі домени застосунку «Дія» до категорії українських сервісів
- синхронізовано підсумковий whitelist із новими доменами

## Перевірка
- тестування не запускалося (оновлення списків доменів)

------
https://chatgpt.com/codex/tasks/task_e_68d82d27fb00832eab16a24aa0462a8c