### PR TITLE
Оновлено перелік державних доменів у білому списку

### DIFF
--- a/categories/ukrainian_services.txt
+++ b/categories/ukrainian_services.txt
@@ -16,20 +16,29 @@ rozetka.com.ua   # маркетплейс Rozetka
 ukr.net          # популярний поштовий сервіс
 
 # Урядові сервіси
-acskidd.gov.ua
-ca.tax.gov.ua
-cabinet.tax.gov.ua
-app.diia.gov.ua    # вебверсія застосунку «Дія»
-diia.app          # офіційний сайт застосунку «Дія»
-diia.gov.ua
-e-data.gov.ua
-eauction.gov.ua
-id.gov.ua
-login.diia.gov.ua
-portal.pfu.gov.ua
-spending.gov.ua
-trembita.gov.ua
-zakupki.prom.ua
+acskidd.gov.ua       # акредитований центр сертифікації ключів ДПС
+app.diia.gov.ua      # вебверсія застосунку «Дія»
+ca.tax.gov.ua        # сертифікаційний центр ДПС
+cabinet.tax.gov.ua   # електронний кабінет платника податків
+diia.app             # офіційний сайт застосунку «Дія»
+diia.gov.ua          # портал державних послуг «Дія»
+e-data.gov.ua        # відкриті дані про публічні фінанси
+eauction.gov.ua      # електронні аукціони ProZorro.Продажі
+gov.ua               # єдиний державний вебпортал
+gromada.gov.ua       # державний портал громад
+id.gov.ua            # система ідентифікації ID.GOV.UA
+kmu.gov.ua           # Кабінет Міністрів України
+login.diia.gov.ua    # авторизація порталу «Дія»
+pfu.gov.ua           # офіційний сайт Пенсійного фонду України
+portal.pfu.gov.ua    # електронні послуги Пенсійного фонду
+poslugy.gov.ua       # єдиний портал державних послуг
+president.gov.ua     # Офіс Президента України
+prozorro.gov.ua      # публічні закупівлі ProZorro
+rada.gov.ua          # Верховна Рада України
+spending.gov.ua      # портал використання публічних коштів
+tax.gov.ua           # Державна податкова служба України
+trembita.gov.ua      # система взаємодії державних реєстрів
+zakon.rada.gov.ua    # база нормативно-правових актів України
 
 # Банківські сервіси
 api.monobank.ua

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -331,9 +331,11 @@ google.com
 googleapis.com
 googleapis.l.google.com
 googletagmanager.com
+gov.ua
 graph.facebook.com
 graph.instagram.com
 graph.microsoft.com
+gromada.gov.ua
 gravatar.com
 gs.apple.com
 gsa.apple.com
@@ -388,6 +390,7 @@ js.maxmind.com
 jsdelivr.net
 keystone.mwbsys.com
 khanacademy.org
+kmu.gov.ua
 l.facebook.com
 l.messenger.com
 lastfm-img2.akamaized.net
@@ -506,6 +509,7 @@ pay.monobank.ua
 payhub.privatbank.ua
 payoneer.com
 paypal.com
+pfu.gov.ua
 pb.ua
 perplexity.ai
 pg-bootstrap.itunes.apple.com
@@ -532,9 +536,11 @@ portal.fb.com
 portal.pfu.gov.ua
 pos-device.apple.com
 posarprodcssservice.accesscontrol.windows.net
+poslugy.gov.ua
 ppq.apple.com
 pravda.com.ua
 pricelist.skype.com
+president.gov.ua
 primevideo.com
 privat24.ua
 privatbank.ua
@@ -542,6 +548,7 @@ prod.telemetry.ros.rockstargames.com
 products.office.com
 prom.ua
 prometheus.org.ua
+prozorro.gov.ua
 proxy.plex.bz
 proxy.plex.tv
 proxy02.pop.ord.plex.bz
@@ -568,6 +575,7 @@ revolut.com
 riotgames.com
 rockstargames.com
 rozetka.com.ua
+rada.gov.ua
 rupload.facebook.com
 s.cdn.turner.com
 s.gateway.messenger.live.com
@@ -674,6 +682,7 @@ t.co
 t.ly
 t0.ssl.ak.dynamic.tiles.virtualearth.net
 t0.ssl.ak.tiles.virtualearth.net
+tax.gov.ua
 tawk.to
 tbsc.apple.com
 teams.cloudflare.com
@@ -836,6 +845,7 @@ youtube.com
 youtubei.googleapis.com
 yt3.ggpht.com
 z.cdn.turner.com
+zakon.rada.gov.ua
 zakupki.prom.ua
 zee.cws.conviva.com
 zeustracker.abuse.ch


### PR DESCRIPTION
## Summary
- розширено секцію державних сервісів у categories/ukrainian_services.txt новими офіційними доменами та поясненнями
- синхронізовано whitelist.txt з новими державними доменами для прямого імпорту до Pi-hole

## Testing
- not run (зміни лише в даних)


------
https://chatgpt.com/codex/tasks/task_e_68d8e66227ac832eae4a8178f0bf448a