### PR TITLE
Add smart home camera hosts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -26,6 +26,7 @@ Available files include:
 - `ukrainian_services.txt` — popular Ukrainian services and banks;
 - `cloud_storage.txt` — cloud platforms (Google Drive, MEGA, Synology etc.);
 - `messengers.txt` — domains for Telegram, WhatsApp, Discord;
+- `smart_home_devices.txt` — Hikvision, Dahua, Yi Home cameras and the Tuya platform;
 - `ntp_servers.txt` — NTP time servers;
 - `gaming.txt` — domains for Steam, Epic Games, Riot, Blizzard and Wargaming;
 - `web_resources.txt` — CDNs and hosts for website scripts and styles;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - `ukrainian_services.txt` — популярні українські сервіси та банки;
 - `cloud_storage.txt` — хмарні сховища (Google Drive, MEGA, Synology тощо);
 - `messengers.txt` — домени Telegram, WhatsApp, Discord;
+- `smart_home_devices.txt` — камери Hikvision, Dahua, Yi Home та платформа Tuya;
 - `ntp_servers.txt` — сервери точного часу (NTP).
 - `gaming.txt` — домени популярних ігор і сервісів (Steam, Epic Games, Riot, Blizzard, Wargaming).
 - `web_resources.txt` — CDN та хости скриптів і стилів для вигляду сайтів.

--- a/categories/smart_home_devices.txt
+++ b/categories/smart_home_devices.txt
@@ -1,0 +1,24 @@
+# Пристрої розумного дому та камери відеоспостереження (оновлено 2025-03-19)
+# Hikvision / Hik-Connect
+hikvision.com           # основний сайт та платформа Hikvision
+hik-connect.com         # хмарний сервіс Hik-Connect
+litedev.ys7.com         # API Hik-Connect для мобільних застосунків
+p2p.ys7.com             # P2P-підключення камер Hikvision
+
+# Dahua / DMSS
+dahuatech.com           # офіційні сервіси Dahua Technology
+dahuasecurity.com       # глобальний портал підтримки Dahua
+dmss.dahuatech.com      # мобільний застосунок Dahua DMSS
+p2p.dahuatech.com       # P2P-мережа Dahua для віддаленого доступу
+
+# Yi Home / Yi Technology
+yitechnology.com        # акаунти та налаштування Yi Technology
+xiaoyi.com              # альтернативний домен Yi (Китай)
+cloudcameraiot.oss-cn-shanghai.aliyuncs.com  # сховище відео Yi Home
+api.xiaoyi.com          # API для застосунків Yi Home
+
+# Tuya Smart
+tuya.com                # Tuya Smart — глобальна платформа IoT
+tuyaus.com              # Tuya — регіональний кластер США
+tuyaeu.com              # Tuya — регіональний кластер ЄС
+ty-iot.com              # службові домени Tuya для пристроїв

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -101,6 +101,7 @@ api.rlje.net
 api.sbs.com.au
 api.telegram.org
 api.twitter.com
+api.xiaoyi.com
 apis.live.net
 app-api.ted.com
 app-site-association.cdn-apple.com
@@ -193,6 +194,7 @@ cloud.mycrealitycloud.com
 cloudflare-dns.com
 cloudflare.com
 cloudflarewarp.com
+cloudcameraiot.oss-cn-shanghai.aliyuncs.com
 cls-ingest.itunes.apple.com
 cls-iosclient.itunes.apple.com
 cms.souqcdn.com
@@ -223,6 +225,9 @@ cwtv-prod-elb.digitalsmiths.net
 d2c8v52ll5s99u.cloudfront.net
 d2gatte9o95jao.cloudfront.net
 d83eunklitikj.cloudfront.net
+dahuasecurity.com
+dahuatech.com
+dmss.dahuatech.com
 dashboard.plex.tv
 dataplicity.com
 dcs-vod.apis.anvato.net
@@ -362,6 +367,8 @@ guzzoni.apple.com
 hbomax.com
 help.cloudflare.com
 help.ui.xboxlive.com
+hik-connect.com
+hikvision.com
 hls.ted.com
 hosts-file.net
 hostsfile.mine.nu
@@ -415,6 +422,7 @@ licensing.xboxlive.com
 link.theplatform.com
 linkedin.com
 liqpay.ua
+litedev.ys7.com
 live.com
 livegrid.eset.com
 livepassdl.conviva.com
@@ -516,6 +524,8 @@ outlook.com
 outlook.live.com
 outlook.office365.com
 ow.ly
+p2p.dahuatech.com
+p2p.ys7.com
 p.sfx.ms
 pandasecurity.com
 pay.monobank.ua
@@ -747,6 +757,10 @@ ttlivecdn.com
 ttoversea.net
 ttoverseaus.net
 turn1.whispersystems.org
+tuya.com
+tuyaeu.com
+tuyaus.com
+ty-iot.com
 tvdb2.plex.tv
 tvthemes.plexapp.com
 twimg.com
@@ -843,6 +857,7 @@ www.signal.org
 www.synology.com
 www.xboxlive.com
 www.youtube-nocookie.com
+xiaoyi.com
 x.com
 xbox.com
 xbox.ipv6.microsoft.com
@@ -852,6 +867,7 @@ xkms.xboxlive.com
 xp-cdn.apple.com
 xp.apple.com
 xsts.auth.xboxlive.com
+yitechnology.com
 youtu.be
 youtube-nocookie.com
 youtube.com


### PR DESCRIPTION
## Summary
- add a dedicated smart_home_devices category covering Hikvision, Dahua, Yi Home, and Tuya domains
- document the new category in both README files
- extend the combined whitelist with the corresponding hosts

## Testing
- not run (data update)


------
https://chatgpt.com/codex/tasks/task_e_68d99ae55ab8832ea17e6abada4ea747