### PR TITLE
Оновити AI-домени у білому списку

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -1,12 +1,15 @@
 # AI-сервіси — платформи для роботи з ШІ
 anthropic.com            # інформація та документація Anthropic
 api.openai.com           # API ChatGPT
+chatgpt.com              # веб-інтерфейс ChatGPT
 claude.ai                # сервіс Claude від Anthropic
 cohere.ai                # сервіс Cohere API
 gemini.google.com        # Google Gemini (раніше Bard)
+grok.com                 # Grok від xAI
 huggingface.co           # платформа HuggingFace
 openai.com               # офіційний сайт OpenAI
 perplexity.ai            # пошук з AI
 platform.openai.com      # веб-інтерфейс OpenAI
 replicate.com            # запуск AI-моделей
 stability.ai             # розробник Stable Diffusion
+x.ai                     # головна сторінка xAI

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -180,6 +180,7 @@ cert.mgt.xboxlive.com
 certs.apple.com
 cf-v4.cloudflare.com
 chat.signal.org
+chatgpt.com
 clamav.net
 claude.ai
 client-s.gateway.messenger.live.com
@@ -355,6 +356,7 @@ graph.instagram.com
 graph.microsoft.com
 gravatar.com
 gromada.gov.ua
+grok.com
 gs.apple.com
 gsa.apple.com
 gsp-ssl.ls-apple.com.akadns.net
@@ -858,6 +860,7 @@ www.synology.com
 www.xboxlive.com
 www.youtube-nocookie.com
 xiaoyi.com
+x.ai
 x.com
 xbox.com
 xbox.ipv6.microsoft.com


### PR DESCRIPTION
## Summary
- додано домени chatgpt.com, grok.com та x.ai до категорії AI-сервісів
- синхронізовано whitelist.txt з новими AI-доменами

## Testing
- не запускались


------
https://chatgpt.com/codex/tasks/task_e_68dfc264ac38832e896414669cbf18f1