### PR TITLE
Додати нові AI-домени до білого списку

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -4,11 +4,14 @@ api.openai.com           # API ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
 claude.ai                # сервіс Claude від Anthropic
 cohere.ai                # сервіс Cohere API
+copilot.microsoft.com    # веб-інтерфейс Microsoft Copilot
+deepseek.com             # платформа DeepSeek
 gemini.google.com        # Google Gemini (раніше Bard)
 grok.com                 # Grok від xAI
 huggingface.co           # платформа HuggingFace
 openai.com               # офіційний сайт OpenAI
 perplexity.ai            # пошук з AI
+poe.com                  # AI-чатботи від Quora
 platform.openai.com      # веб-інтерфейс OpenAI
 replicate.com            # запуск AI-моделей
 stability.ai             # розробник Stable Diffusion

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -202,6 +202,7 @@ cms.souqcdn.com
 code.jquery.com
 cognito-identity.us-east-1.amazonaws.com
 cohere.ai
+copilot.microsoft.com
 configuration.apple.com
 connect.facebook.com
 connectivity.cloudflareclient.com
@@ -232,6 +233,7 @@ dmss.dahuatech.com
 dashboard.plex.tv
 dataplicity.com
 dcs-vod.apis.anvato.net
+deepseek.com
 deezer.com
 def-vef.xboxlive.com
 defs.symantec.com
@@ -555,6 +557,7 @@ playgrounds-cdn.apple.com
 playstation.com
 playvalorant.com
 pmd.cdn.turner.com
+poe.com
 policies.live.net
 pool.ntp.org
 portal.fb.com


### PR DESCRIPTION
## Summary
- додано домени Microsoft Copilot, DeepSeek та Poe до категорії AI-сервісів
- синхронізовано згенерований whitelist.txt з новими AI-доменами

## Testing
- not run (не потрібно для оновлення списків)

------
https://chatgpt.com/codex/tasks/task_e_68e423086f70832eb03af33a6eacb56e