### PR TITLE
Додати опцію вихідного файлу для generate_whitelist.sh

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -69,9 +69,11 @@ The `generate_whitelist.sh` script creates `whitelist.txt` from all files in `ca
 ```bash
 ./generate_whitelist.sh              # all categories
 ./generate_whitelist.sh categories/cloud_storage.txt extra_dir/  # specific files or folders
+./generate_whitelist.sh -o exports/custom.txt                   # save to a custom file
+OUTFILE=exports/custom.txt ./generate_whitelist.sh              # alternative via environment variable
 ```
 
-The resulting file is ready for import into pihole.
+The resulting file is ready for import into pihole. If you specify a path with nested folders, they will be created automatically.
 
 ## External domain sources
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@
 ```bash
 ./generate_whitelist.sh              # всі категорії
 ./generate_whitelist.sh categories/cloud_storage.txt extra_dir/  # вибіркові файли чи каталоги
+./generate_whitelist.sh -o exports/custom.txt                   # запис у довільний файл
+OUTFILE=exports/custom.txt ./generate_whitelist.sh              # альтернатива через змінну середовища
 ```
 
-Сформований файл одразу готовий до імпорту в pihole.
+Сформований файл одразу готовий до імпорту в pihole. Якщо вказати шлях із підкаталогами, вони будуть створені автоматично.
 
 ## Зовнішні джерела доменів
 

--- a/generate_whitelist.sh
+++ b/generate_whitelist.sh
@@ -4,9 +4,66 @@
 # Коментарі (окремі та після доменів) й порожні рядки ігноруються
 set -euo pipefail
 
-OUTFILE="whitelist.txt"
+OUTFILE=${OUTFILE:-"whitelist.txt"}
 SOURCES_COMBINED=${SOURCES_COMBINED:-"sources/generated/all_sources.txt"}
 INCLUDE_EXTERNAL_SOURCES=${INCLUDE_EXTERNAL_SOURCES:-1}
+
+print_usage() {
+  cat <<'EOF'
+Використання: ./generate_whitelist.sh [опції] [файли_or_каталоги]
+
+  -o, --output Файл для збереження результату (за замовчуванням whitelist.txt або значення змінної OUTFILE)
+  -h, --help   Показати цю довідку
+
+Можна передавати як окремі файли, так і каталоги з файлами .txt. Якщо аргументи відсутні,
+буде використано всі файли у каталозі categories/.
+EOF
+}
+
+args=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o|--output)
+      if [ "${2:-}" = "" ]; then
+        echo "Потрібно вказати значення для $1" >&2
+        exit 1
+      fi
+      OUTFILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    --)
+      shift
+      args+=("$@")
+      break
+      ;;
+    -*)
+      echo "Невідомий параметр: $1" >&2
+      exit 1
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#args[@]}" -gt 0 ]; then
+  set -- "${args[@]}"
+else
+  set --
+fi
+
+if [ -z "$OUTFILE" ]; then
+  echo "Ім'я вихідного файлу не може бути порожнім" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTFILE")"
 
 echo "# Автоматично згенеровано скриптом generate_whitelist.sh" > "$OUTFILE"
 

--- a/tests/generate_whitelist_test.sh
+++ b/tests/generate_whitelist_test.sh
@@ -66,4 +66,24 @@ fi
 rm -f sources/generated/all_sources.txt
 rmdir sources/generated 2>/dev/null || true
 
+# Перевірка використання змінної OUTFILE
+rm -f whitelist_custom.txt
+OUTFILE=whitelist_custom.txt ./generate_whitelist.sh >/dev/null
+if ! grep -q '^google.com' whitelist_custom.txt; then
+  echo "Не вдалося створити whitelist_custom.txt через змінну OUTFILE" >&2
+  rm -f whitelist_custom.txt
+  exit 1
+fi
+rm -f whitelist_custom.txt
+
+# Перевірка опції -o/--output з каталогом
+rm -rf tmp_output
+./generate_whitelist.sh -o tmp_output/alt_whitelist.txt >/dev/null
+if ! grep -q '^google.com' tmp_output/alt_whitelist.txt; then
+  echo "Опція -o не створила очікуваний файл" >&2
+  rm -rf tmp_output
+  exit 1
+fi
+rm -rf tmp_output
+
 echo "Інтеграційний тест успішно пройдено"


### PR DESCRIPTION
## Summary
- додано підтримку опцій -o/--output та змінної OUTFILE у generate_whitelist.sh разом із довідкою та автотворенням каталогів
- оновлено документацію (README та README.en.md) з новими прикладами використання
- розширено тести generate_whitelist_test.sh для перевірки нових сценаріїв

## Testing
- tests/generate_whitelist_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e4259a9620832e83d00d757e48578f