### PR TITLE
Оновлення доменів білого списку

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -1,4 +1,5 @@
 # AI-сервіси — платформи для роботи з ШІ
+aistudio.google.com      # інтерфейс Google AI Studio
 anthropic.com            # інформація та документація Anthropic
 api.openai.com           # API ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
@@ -9,6 +10,7 @@ deepseek.com             # платформа DeepSeek
 gemini.google.com        # Google Gemini (раніше Bard)
 grok.com                 # Grok від xAI
 huggingface.co           # платформа HuggingFace
+mistral.ai               # генеративні моделі Mistral
 openai.com               # офіційний сайт OpenAI
 perplexity.ai            # пошук з AI
 poe.com                  # AI-чатботи від Quora

--- a/categories/messengers.txt
+++ b/categories/messengers.txt
@@ -4,6 +4,7 @@ cdn.telegram.org        # CDN Telegram
 core.telegram.org          # документація Telegram
 discord.com             # чат Discord
 messenger.com           # вебверсія Facebook Messenger
+signal.org              # офіційний сайт Signal із завантаженнями клієнтів
 telegram.org            # месенджер Telegram
 whatsapp.com            # месенджер WhatsApp
 eyecon-app.com         # телефонна книга Eyecon

--- a/categories/social_networks.txt
+++ b/categories/social_networks.txt
@@ -3,6 +3,7 @@ facebook.com
 instagram.com
 linkedin.com
 pinterest.com
+threads.net         # соцмережа Threads від Meta
 snapchat.com
 tiktok.com
 twitter.com

--- a/categories/streaming_services.txt
+++ b/categories/streaming_services.txt
@@ -4,6 +4,7 @@ disneyplus.com
 hbomax.com            # старий домен HBO Max
 hulu.com
 max.com               # сервіс Max (раніше HBO Max)
+music.youtube.com     # музичний сервіс YouTube Music
 netflix.com
 primevideo.com
 soundcloud.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -60,6 +60,7 @@ activate.adobe.com
 activity.windows.com
 adf.ly
 ae01.alicdn.com
+aistudio.google.com
 ajax.googleapis.com
 akamaihd.net
 akamaitechnologies.com
@@ -192,17 +193,16 @@ clients4.google.com
 clients5.google.com
 clients6.google.com
 cloud.mycrealitycloud.com
+cloudcameraiot.oss-cn-shanghai.aliyuncs.com
 cloudflare-dns.com
 cloudflare.com
 cloudflarewarp.com
-cloudcameraiot.oss-cn-shanghai.aliyuncs.com
 cls-ingest.itunes.apple.com
 cls-iosclient.itunes.apple.com
 cms.souqcdn.com
 code.jquery.com
 cognito-identity.us-east-1.amazonaws.com
 cohere.ai
-copilot.microsoft.com
 configuration.apple.com
 connect.facebook.com
 connectivity.cloudflareclient.com
@@ -210,6 +210,7 @@ connectivitycheck.android.com
 connectivitycheck.gstatic.com
 contentproxy.signal.org
 continuum.dds.microsoft.com
+copilot.microsoft.com
 core.telegram.org
 coursera.org
 cpms.spop10.ams.plex.bz
@@ -229,7 +230,6 @@ d2gatte9o95jao.cloudfront.net
 d83eunklitikj.cloudfront.net
 dahuasecurity.com
 dahuatech.com
-dmss.dahuatech.com
 dashboard.plex.tv
 dataplicity.com
 dcs-vod.apis.anvato.net
@@ -263,6 +263,7 @@ dl.dropbox.com
 dl.dropboxusercontent.com
 dl.google.com
 dmd.metaservices.microsoft.com
+dmss.dahuatech.com
 dns.google
 dns.msftncsi.com
 docs.google.com
@@ -357,8 +358,8 @@ graph.facebook.com
 graph.instagram.com
 graph.microsoft.com
 gravatar.com
-gromada.gov.ua
 grok.com
+gromada.gov.ua
 gs.apple.com
 gsa.apple.com
 gsp-ssl.ls-apple.com.akadns.net
@@ -465,6 +466,7 @@ microsoft.com
 microsoft365.com
 microsoftonline.com
 microsoftteams.com
+mistral.ai
 mobile-ap.spotify.com
 mobile.twitter.com
 monobank.ua
@@ -476,6 +478,7 @@ msftncsi.com
 msn.com
 mssdk-va.tiktok.com
 mtalk.google.com
+music.youtube.com
 my.novaposhta.ua
 my.plexapp.com
 naurok.ua
@@ -528,9 +531,9 @@ outlook.com
 outlook.live.com
 outlook.office365.com
 ow.ly
+p.sfx.ms
 p2p.dahuatech.com
 p2p.ys7.com
-p.sfx.ms
 pandasecurity.com
 pay.monobank.ua
 payhub.privatbank.ua
@@ -720,6 +723,7 @@ telegram.org
 textsecure-service-whispersystems.org
 themoviedb.com
 thetvdb.com
+threads.net
 thumbs.redditmedia.com
 tiktok.com
 tiktok.in
@@ -765,11 +769,11 @@ turn1.whispersystems.org
 tuya.com
 tuyaeu.com
 tuyaus.com
-ty-iot.com
 tvdb2.plex.tv
 tvthemes.plexapp.com
 twimg.com
 twitter.com
+ty-iot.com
 ua.pool.ntp.org
 ud-chat.signal.org
 ui.skype.com
@@ -862,13 +866,13 @@ www.signal.org
 www.synology.com
 www.xboxlive.com
 www.youtube-nocookie.com
-xiaoyi.com
 x.ai
 x.com
 xbox.com
 xbox.ipv6.microsoft.com
 xboxexperiencesprod.experimentation.xboxlive.com
 xflight.xboxlive.com
+xiaoyi.com
 xkms.xboxlive.com
 xp-cdn.apple.com
 xp.apple.com


### PR DESCRIPTION
## Summary
- додано нові домени AI-сервісів (Google AI Studio та Mistral)
- розширено списки соціальних мереж, месенджерів і стрімінгових платформ (Threads, Signal, YouTube Music)
- перегенеровано загальний whitelist зі свіжими записами

## Testing
- not run (оновлено лише дані)


------
https://chatgpt.com/codex/tasks/task_e_68e47de89904832e9b5b0cf736930ddc