### PR TITLE
fix: додано домени Xiaomi Mi Cloud до білого списку

### DIFF
--- a/categories/cloud_storage.txt
+++ b/categories/cloud_storage.txt
@@ -23,3 +23,14 @@ box.com                  # сервіс Box
 dropbox.com              # сервіс Dropbox
 *.dropbox.com            # піддомени Dropbox
 
+# Xiaomi Mi Cloud — резервні копії та синхронізація MIUI (2024-05-19)
+micloud.xiaomi.net              # головний портал Mi Cloud
+*.micloud.xiaomi.net            # регіональні кластери Mi Cloud
+api.micloud.xiaomi.net          # API резервних копій та синхронізації
+statusapi.micloud.xiaomi.net    # перевірка стану сервісів Mi Cloud
+user.micloud.xiaomi.net         # авторизація облікових записів Xiaomi
+galleryapi.micloud.xiaomi.net   # синхронізація галереї та медіа
+locationapi.micloud.xiaomi.net  # пошук пристрою та геолокація
+finderapi.micloud.xiaomi.net    # пошук пристрою Find Device
+i.mi.com                        # веб-інтерфейс Mi Cloud
+


### PR DESCRIPTION
**Опис змін:**
- додано перелік основних доменів сервісу Xiaomi Mi Cloud до категорії хмарних сховищ, щоб працювали резервні копії та синхронізація на пристроях Xiaomi/Poco.

**Тип зміни:** fix

**Посилання на задачу/квиток:** #SUP-0

**Перевірки:**
- [ ] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

**Вплив:** зміни стосуються лише білого списку доменів, сумісність не порушено.

**Скрін/лог/профіль (за потреби):** не потребує.


------
https://chatgpt.com/codex/tasks/task_e_68ea10745a6c832ea6d701bd845f424b