### PR TITLE
feat: оновлено домени для сервісів OpenAI

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -3,6 +3,7 @@ aistudio.google.com      # інтерфейс Google AI Studio
 anthropic.com            # інформація та документація Anthropic
 api.openai.com           # API ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
+chat.openai.com          # вебклієнт ChatGPT на домені openai.com
 claude.ai                # сервіс Claude від Anthropic
 cohere.ai                # сервіс Cohere API
 copilot.microsoft.com    # веб-інтерфейс Microsoft Copilot
@@ -11,6 +12,7 @@ gemini.google.com        # Google Gemini (раніше Bard)
 grok.com                 # Grok від xAI
 huggingface.co           # платформа HuggingFace
 mistral.ai               # генеративні моделі Mistral
+oaistatic.com            # статичні ресурси для ChatGPT
 openai.com               # офіційний сайт OpenAI
 perplexity.ai            # пошук з AI
 poe.com                  # AI-чатботи від Quora

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -182,6 +182,7 @@ cdns.gigya.com
 cert.mgt.xboxlive.com
 certs.apple.com
 cf-v4.cloudflare.com
+chat.openai.com
 chat.signal.org
 chatgpt.com
 clamav.net
@@ -508,6 +509,7 @@ oauth.live.com
 oauthaccountmanager.googleapis.com
 ocsp.apple.com
 ocsp.digicert.com
+oaistatic.com
 ocsp.pki.goog
 ocsp.rootg2.amazontrust.com
 ocsp.usertrust.com


### PR DESCRIPTION
## Опис змін
- додано chat.openai.com та oaistatic.com до категорії AI-сервісів для повнішого покриття інфраструктури ChatGPT
- синхронізовано whitelist.txt з новими доменами, щоб уникнути блокувань вебклієнта та статичних ресурсів

## Тип зміни
- feat

## Посилання на задачу/квиток
- #WL-000

## Перевірки:
- [x] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- не впливає на публічні API; покращено доступність сервісів OpenAI

## Скрін/лог/профіль (за потреби)
- не потрібно

------
https://chatgpt.com/codex/tasks/task_e_68ebfee2eeb4832e87dab9133ca3e55a