### PR TITLE
feat: додано REST API для генерації whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,33 @@ CATEGORIES_DIR=my_lists THRESHOLD=5 LOG_FILE=my.log ./cleanup_whitelist.sh
 ## Ліцензія
 
 Вміст репозиторію поширюється за умовами MIT License. Деталі в файлі `LICENSE`.
+
+## REST API та веб-форма для вибіркової генерації
+
+Для автоматизації побудови whitelist за категоріями додано прототип REST API `whitelist_builder_api.py`. Він запускає локальний сервер, який переиспользує скрипт `build_whitelist.sh` та надає кілька допоміжних ендпоінтів.
+
+### Запуск сервера
+```bash
+python3 whitelist_builder_api.py --host 127.0.0.1 --port 5050 \
+  --data-dir /tmp/whitelists --log-file /tmp/whitelist_builder.log
+```
+Основні параметри можна змінювати: `--categories-dir` (каталог з файлами категорій), `--allow-extra-path` (дозволені додаткові каталоги), `--allow-external-categories` (щоб приймати абсолютні шляхи файлів).
+
+Після запуску доступні такі ендпоінти:
+- `GET /health` — перевірка стану сервера;
+- `GET /api/categories` — перелік категорій із коротким описом і кількістю доменів;
+- `POST /api/build` — формування whitelist за вибраними параметрами;
+- `GET /downloads/<файл>` — завантаження сформованого файлу.
+
+Приклад запиту до `POST /api/build`:
+```bash
+curl -X POST http://127.0.0.1:5050/api/build \
+  -H 'Content-Type: application/json' \
+  -d '{"categories":["base.txt","apple.txt"],"include_external":true}'
+```
+У відповіді повертається кількість доменів та шлях до згенерованого файла.
+
+### Базова веб-форма
+У каталозі `web/` додано сторінку `whitelist_builder.html`, яка взаємодіє з API: завантажує перелік категорій, дає змогу відмітити потрібні та надіслати запит на генерацію. Щоб скористатися інтерфейсом, запустіть веб-сервер (наприклад, `python3 -m http.server` у корені репозиторію) та відкрийте `http://127.0.0.1:8000/web/whitelist_builder.html` у браузері.
+
+Форма відображає опис категорій, параметри зовнішніх джерел і виводить JSON-відповідь API з посиланням на файл.

--- a/tests/whitelist_builder_api_test.sh
+++ b/tests/whitelist_builder_api_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl не знайдено" >&2
+  exit 1
+fi
+
+port=$(python3 - <<'PY'
+import random
+print(random.randint(40000, 50000))
+PY
+)
+
+tmpdir=$(mktemp -d)
+server_log="$tmpdir/server.log"
+server_pid=""
+
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+    server_pid=""
+  fi
+  rm -rf "$tmpdir"
+}
+
+trap 'cleanup' EXIT
+
+python3 whitelist_builder_api.py \
+  --host 127.0.0.1 \
+  --port "$port" \
+  --data-dir "$tmpdir/output" \
+  --log-file "$tmpdir/api.log" \
+  >"$server_log" 2>&1 &
+server_pid=$!
+
+for attempt in $(seq 1 50); do
+  if curl -fs "http://127.0.0.1:$port/health" >/dev/null; then
+    break
+  fi
+  sleep 0.2
+done
+
+if ! curl -fs "http://127.0.0.1:$port/health" >/dev/null; then
+  echo "API не відповідає" >&2
+  if [[ -f "$server_log" ]]; then
+    cat "$server_log" >&2
+  fi
+  exit 1
+fi
+
+categories_json=$(curl -fs "http://127.0.0.1:$port/api/categories")
+CATEGORIES_PAYLOAD="$categories_json" python3 <<'PY'
+import json, os
+payload = json.loads(os.environ["CATEGORIES_PAYLOAD"])
+if payload.get("status") != "ok":
+    raise SystemExit("Некоректна відповідь /api/categories")
+if not payload.get("categories"):
+    raise SystemExit("Перелік категорій порожній")
+PY
+
+response=$(curl -fs -X POST "http://127.0.0.1:$port/api/build" \
+  -H 'Content-Type: application/json' \
+  -d '{"categories":["base.txt"],"include_external":false}')
+
+RESPONSE_PAYLOAD="$response" python3 <<'PY'
+import json, os
+payload = json.loads(os.environ["RESPONSE_PAYLOAD"])
+if payload.get("status") != "ok":
+    raise SystemExit("Очікував статус ok")
+if payload.get("domain_count", 0) <= 0:
+    raise SystemExit("Нульова кількість доменів")
+url = payload.get("download_url")
+if not url or not url.startswith("/downloads/"):
+    raise SystemExit("Некоректний download_url")
+PY
+
+file_name=$(RESPONSE_PAYLOAD="$response" python3 <<'PY'
+import json, os
+payload = json.loads(os.environ["RESPONSE_PAYLOAD"])
+print(payload["download_url"].split("/")[-1])
+PY
+)
+file_path="$tmpdir/output/$file_name"
+
+if [[ ! -s "$file_path" ]]; then
+  echo "Згенерований файл не знайдено" >&2
+  exit 1
+fi
+
+if curl -fs "http://127.0.0.1:$port/api/build" -H 'Content-Type: application/json' -d '{}' >/dev/null; then
+  echo "Порожній запит мав завершитися помилкою" >&2
+  exit 1
+fi
+
+kill "$server_pid" 2>/dev/null || true
+wait "$server_pid" 2>/dev/null || true
+server_pid=""
+
+echo "Тест whitelist_builder_api пройдено"

--- a/web/whitelist_builder.html
+++ b/web/whitelist_builder.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="utf-8">
+  <title>Whitelist Builder</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    .categories { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .category { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .category h3 { margin: 0 0 0.5rem; font-size: 1rem; }
+    .result { background: #f5f5f5; border-radius: 8px; padding: 1rem; white-space: pre-wrap; }
+    button { padding: 0.6rem 1.2rem; border: none; border-radius: 6px; cursor: pointer; }
+    button.primary { background: #2563eb; color: white; }
+    button.secondary { background: #e5e7eb; }
+    .controls { display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap; }
+    label { display: flex; align-items: center; gap: 0.4rem; }
+    .status { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Прототип Whitelist Builder</h1>
+  <p>Форма взаємодіє з локальним API <code>whitelist_builder_api.py</code>. Спочатку запустіть сервер: <code>python3 whitelist_builder_api.py</code>.</p>
+  <div class="controls">
+    <button type="button" id="reload" class="secondary">Оновити категорії</button>
+    <label><input type="checkbox" id="includeExternal" checked> Включати зовнішні джерела</label>
+    <label><input type="checkbox" id="applyDirectly"> Одразу застосувати через Pi-hole</label>
+  </div>
+  <div id="categories" class="categories"></div>
+  <form id="builderForm">
+    <div style="margin-bottom: 1rem;">
+      <label>Кастомний файл джерел:<br><input type="text" id="sourcesCombined" placeholder="/path/to/all_sources.txt" style="width: 320px;"></label>
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <label>Додаткові шляхи (через кому):<br><input type="text" id="extraPaths" placeholder="/srv/custom1,/srv/custom2" style="width: 320px;"></label>
+    </div>
+    <button type="submit" class="primary">Згенерувати whitelist</button>
+  </form>
+  <div id="status" class="status"></div>
+  <div id="result" class="result" hidden></div>
+
+  <script>
+    const categoriesContainer = document.getElementById('categories');
+    const statusBox = document.getElementById('status');
+    const resultBox = document.getElementById('result');
+
+    async function loadCategories() {
+      statusBox.textContent = 'Завантаження категорій…';
+      resultBox.hidden = true;
+      try {
+        const response = await fetch('/api/categories');
+        if (!response.ok) {
+          throw new Error('Помилка завантаження категорій');
+        }
+        const data = await response.json();
+        renderCategories(data.categories || []);
+        statusBox.textContent = `Доступно категорій: ${data.categories.length}`;
+      } catch (error) {
+        statusBox.textContent = error.message;
+        categoriesContainer.innerHTML = '';
+      }
+    }
+
+    function renderCategories(categories) {
+      categoriesContainer.innerHTML = '';
+      categories.forEach((item) => {
+        const wrapper = document.createElement('label');
+        wrapper.className = 'category';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.value = item.name;
+        wrapper.appendChild(checkbox);
+        const title = document.createElement('h3');
+        title.textContent = `${item.name} (${item.domain_count})`;
+        wrapper.appendChild(title);
+        if (item.description) {
+          const description = document.createElement('p');
+          description.textContent = item.description;
+          wrapper.appendChild(description);
+        }
+        categoriesContainer.appendChild(wrapper);
+      });
+    }
+
+    document.getElementById('reload').addEventListener('click', loadCategories);
+
+    document.getElementById('builderForm').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const selectedCategories = Array.from(categoriesContainer.querySelectorAll('input[type="checkbox"]:checked')).map((input) => input.value);
+      if (selectedCategories.length === 0) {
+        statusBox.textContent = 'Оберіть принаймні одну категорію.';
+        return;
+      }
+      const payload = {
+        categories: selectedCategories,
+        include_external: document.getElementById('includeExternal').checked,
+        apply_directly: document.getElementById('applyDirectly').checked,
+        sources_combined: document.getElementById('sourcesCombined').value.trim(),
+        extra_paths: document.getElementById('extraPaths').value.split(',').map((item) => item.trim()).filter(Boolean),
+      };
+      statusBox.textContent = 'Генерація…';
+      resultBox.hidden = true;
+      try {
+        const response = await fetch('/api/build', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await response.json();
+        if (!response.ok || data.status !== 'ok') {
+          throw new Error((data.errors && data.errors.join('; ')) || 'Невідома помилка генерації');
+        }
+        statusBox.textContent = `Створено ${data.domain_count} доменів. Посилання на файл: ${data.download_url}`;
+        resultBox.hidden = false;
+        resultBox.textContent = JSON.stringify(data, null, 2);
+      } catch (error) {
+        statusBox.textContent = error.message;
+      }
+    });
+
+    loadCategories();
+  </script>
+</body>
+</html>

--- a/whitelist_builder_api.py
+++ b/whitelist_builder_api.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Прототип REST API для build_whitelist.sh."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import threading
+import uuid
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from subprocess import CalledProcessError, run
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class CategoryInfo:
+    name: str
+    path: pathlib.Path
+    domain_count: int
+    description: str
+
+
+ROOT = pathlib.Path(__file__).resolve().parent
+
+
+def _read_json(handler: BaseHTTPRequestHandler) -> Any:
+    length_header = handler.headers.get("Content-Length")
+    if not length_header:
+        raise ValueError("Відсутній заголовок Content-Length")
+    try:
+        length = int(length_header)
+    except ValueError as exc:  # pragma: no cover - захист від некоректних значень
+        raise ValueError("Content-Length має бути числом") from exc
+    payload = handler.rfile.read(length)
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Не вдалося розпарсити JSON") from exc
+
+
+def _safe_join(base: pathlib.Path, *parts: str) -> pathlib.Path:
+    candidate = (base.joinpath(*parts)).resolve()
+    if base not in candidate.parents and candidate != base:
+        raise ValueError("Шлях виходить за межі дозволеного каталогу")
+    return candidate
+
+
+def _count_domains(path: pathlib.Path) -> int:
+    count = 0
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            count += 1
+    return count
+
+
+def _append_log(path: pathlib.Path, message: str) -> None:
+    timestamp = dt.datetime.utcnow().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\t{message}\n")
+
+
+
+class BuilderConfig:
+    """Налаштування сервера."""
+
+    def collect_categories(self) -> List[CategoryInfo]:
+        items: List[CategoryInfo] = []
+        if not self.categories_dir.exists():
+            return items
+        for path in sorted(self.categories_dir.glob("*.txt")):
+            if path.name == "deprecated.txt":
+                continue
+            count = _count_domains(path)
+            description = self._extract_description(path)
+            items.append(
+                CategoryInfo(name=path.name, path=path, domain_count=count, description=description)
+            )
+        return items
+
+    def _extract_description(self, path: pathlib.Path) -> str:
+        description_lines: List[str] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    if description_lines:
+                        break
+                    continue
+                if stripped.startswith("#"):
+                    description_lines.append(stripped.lstrip("# "))
+                    continue
+                break
+        return " ".join(description_lines).strip()
+
+    def __init__(
+        self,
+        build_script: pathlib.Path,
+        data_dir: pathlib.Path,
+        log_file: pathlib.Path,
+        categories_dir: pathlib.Path,
+        allow_external_categories: bool,
+        allowed_extra_paths: Optional[List[pathlib.Path]],
+    ) -> None:
+        self.build_script = build_script
+        self.data_dir = data_dir
+        self.log_file = log_file
+        self.categories_dir = categories_dir
+        self.allow_external_categories = allow_external_categories
+        self.allowed_extra_paths = allowed_extra_paths or []
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def resolve_category(self, value: str) -> pathlib.Path:
+        raw = pathlib.Path(value)
+        if raw.is_absolute():
+            candidate = raw.resolve()
+            if not self.allow_external_categories and not candidate.is_relative_to(self.categories_dir):
+                raise ValueError("Зовнішні категорії заборонено політикою сервера")
+        else:
+            candidate = _safe_join(self.categories_dir, value)
+        if not candidate.exists():
+            raise ValueError(f"Категорію {value} не знайдено")
+        return candidate
+
+    def resolve_extra(self, value: str) -> pathlib.Path:
+        candidate = pathlib.Path(value).resolve()
+        if not candidate.exists():
+            raise ValueError(f"Додатковий шлях {value} не існує")
+        if self.allowed_extra_paths:
+            allowed = any(candidate.is_relative_to(base) for base in self.allowed_extra_paths)
+            if not allowed:
+                raise ValueError("Шлях не входить до списку дозволених extra-path")
+        return candidate
+
+
+
+class BuilderHTTPServer(ThreadingHTTPServer):
+    """HTTP-сервер з доступом до конфігурації."""
+
+    def __init__(self, server_address: tuple[str, int], config: BuilderConfig) -> None:
+        super().__init__(server_address, BuilderRequestHandler)
+        self.config = config
+        self._shutdown_requested = threading.Event()
+
+    def shutdown(self) -> None:  # pragma: no cover - викликається при завершенні
+        self._shutdown_requested.set()
+        super().shutdown()
+
+
+class BuilderRequestHandler(BaseHTTPRequestHandler):
+    """Обробник HTTP-запитів для API."""
+
+    server: "BuilderHTTPServer"  # type: ignore[assignment]
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # pragma: no cover - уникнення зайвих логів у stderr
+        _append_log(self.server.config.log_file, fmt % args)
+
+    def _send_json(self, status: HTTPStatus, payload: Dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._send_json(HTTPStatus.OK, {"status": "ok"})
+            return
+        if self.path == "/api/categories":
+            self._handle_categories()
+            return
+        if self.path.startswith("/downloads/"):
+            self._handle_download()
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"status": "error", "errors": ["Ресурс не знайдено"]})
+
+    def _handle_categories(self) -> None:
+        items = [
+            {
+                "name": info.name,
+                "domain_count": info.domain_count,
+                "description": info.description,
+            }
+            for info in self.server.config.collect_categories()
+        ]
+        self._send_json(HTTPStatus.OK, {"status": "ok", "categories": items})
+
+    def _handle_download(self) -> None:
+        relative = self.path[len("/downloads/") :]
+        try:
+            file_path = _safe_join(self.server.config.data_dir, relative)
+        except ValueError:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"status": "error", "errors": ["Некоректний шлях"]})
+            return
+        if not file_path.exists():
+            self._send_json(HTTPStatus.NOT_FOUND, {"status": "error", "errors": ["Файл не знайдено"]})
+            return
+        data = file_path.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/api/build":
+            self._handle_build()
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"status": "error", "errors": ["Ресурс не знайдено"]})
+
+    def _handle_build(self) -> None:
+        try:
+            payload = _read_json(self)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"status": "error", "errors": [str(exc)]})
+            return
+
+        try:
+            request = self._validate_payload(payload)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"status": "error", "errors": [str(exc)]})
+            return
+
+        output_name = f"whitelist-{dt.datetime.utcnow().strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}.txt"
+        output_path = self.server.config.data_dir / output_name
+
+        cmd: List[str] = [str(self.server.config.build_script), "--output", str(output_path)]
+        if request["categories"]:
+            cmd.extend(["--categories", ",".join(str(p) for p in request["categories"])])
+        for extra in request["extra_paths"]:
+            cmd.extend(["--extra-path", str(extra)])
+        cmd.extend(["--include-external", "1" if request["include_external"] else "0"])
+        if request["sources_combined"]:
+            cmd.extend(["--sources-combined", request["sources_combined"]])
+        cmd.extend(["--apply-directly", "1" if request["apply_directly"] else "0"])
+
+        try:
+            completed = run(cmd, capture_output=True, text=True, check=True)
+        except CalledProcessError as exc:
+            errors = ["Не вдалося згенерувати whitelist", exc.stderr.strip() or exc.stdout.strip()]
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"status": "error", "errors": errors})
+            return
+
+        if not output_path.exists():
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"status": "error", "errors": ["Файл результату не створено"]})
+            return
+
+        domain_count = _count_domains(output_path)
+        download_url = f"/downloads/{output_path.name}"
+        log_message = (
+            f"client={self.client_address[0]} categories={len(request['categories'])} "
+            f"domains={domain_count} apply={int(request['apply_directly'])}"
+        )
+        _append_log(self.server.config.log_file, log_message)
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "status": "ok",
+                "domain_count": domain_count,
+                "download_url": download_url,
+                "command_stdout": completed.stdout.strip(),
+            },
+        )
+
+    def _validate_payload(self, payload: Any) -> Dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise ValueError("Очікується JSON-об'єкт")
+        categories_raw = payload.get("categories", [])
+        if not isinstance(categories_raw, list):
+            raise ValueError("Поле categories має бути списком")
+        if not categories_raw:
+            raise ValueError("Потрібно вказати щонайменше одну категорію")
+        categories = [self.server.config.resolve_category(str(item)) for item in categories_raw]
+
+        extra_raw = payload.get("extra_paths", [])
+        if not isinstance(extra_raw, list):
+            raise ValueError("Поле extra_paths має бути списком")
+        extra_paths = [self.server.config.resolve_extra(str(item)) for item in extra_raw]
+
+        include_external = bool(payload.get("include_external", True))
+        apply_directly = bool(payload.get("apply_directly", False))
+        sources_combined = payload.get("sources_combined", "")
+        if sources_combined:
+            sources_combined = str(sources_combined)
+
+        return {
+            "categories": categories,
+            "extra_paths": extra_paths,
+            "include_external": include_external,
+            "apply_directly": apply_directly,
+            "sources_combined": sources_combined,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="REST API для build_whitelist.sh")
+    parser.add_argument("--host", default="127.0.0.1", help="Хост для прослуховування")
+    parser.add_argument("--port", type=int, default=5000, help="Порт для прослуховування")
+    parser.add_argument(
+        "--build-script",
+        default=str(ROOT / "build_whitelist.sh"),
+        help="Шлях до build_whitelist.sh",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(ROOT / "tmp" / "downloads"),
+        help="Каталог для збереження сформованих whitelist-файлів",
+    )
+    parser.add_argument(
+        "--log-file",
+        default=str(ROOT / "logs" / "whitelist_builder.log"),
+        help="Файл журналу операцій",
+    )
+    parser.add_argument(
+        "--categories-dir",
+        default=str(ROOT / "categories"),
+        help="Каталог з файлами категорій",
+    )
+    parser.add_argument(
+        "--allow-external-categories",
+        action="store_true",
+        help="Дозволити абсолютні шляхи категорій поза стандартним каталогом",
+    )
+    parser.add_argument(
+        "--allow-extra-path",
+        action="append",
+        default=[],
+        help="Додаткові дозволені каталоги для extra-path (якщо не вказано — дозволено будь-які існуючі шляхи)",
+    )
+    return parser.parse_args()
+
+
+def build_server(args: argparse.Namespace) -> BuilderHTTPServer:
+    build_script = pathlib.Path(args.build_script).resolve()
+    if not build_script.exists():
+        raise SystemExit(f"Скрипт {build_script} не знайдено")
+    config = BuilderConfig(
+        build_script=build_script,
+        data_dir=pathlib.Path(args.data_dir).resolve(),
+        log_file=pathlib.Path(args.log_file).resolve(),
+        categories_dir=pathlib.Path(args.categories_dir).resolve(),
+        allow_external_categories=bool(args.allow_external_categories),
+        allowed_extra_paths=[pathlib.Path(item).resolve() for item in args.allow_extra_path],
+    )
+    server = BuilderHTTPServer((args.host, args.port), config)
+    return server
+
+
+def main() -> None:
+    args = parse_args()
+    server = build_server(args)
+    print(f"Whitelist Builder API запущено на http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - зручно при ручному запуску
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Опис змін
- реалізовано скрипт `whitelist_builder_api.py` із REST-ендпоінтами `/api/categories`, `/api/build`, `/downloads/*` та health-check
- додано інтеграційний тест `tests/whitelist_builder_api_test.sh`, що перевіряє побудову файлу й обробку помилкових запитів
- створено статичну сторінку `web/whitelist_builder.html` та оновлено README з інструкціями запуску

## Тип зміни
- feat

## Посилання на задачу/квиток
- #ROADMAP

## Перевірки
- [x] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- новий REST API та HTML-сторінка; зворотна сумісність існуючих скриптів не порушена

## Скрін/лог/профіль
- додається скріншот веб-форми в фінальному звіті

------
https://chatgpt.com/codex/tasks/task_e_68ec0f0839f0832e9b08b6de9fde93b2