### PR TITLE
Оновлено звіт статистики та додано англомовний markdown

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <h1>Моніторинг білого списку Pi-hole</h1>
-  <p>Оновлено: 2025-10-12 20:55:10</p>
+  <p>Оновлено: 2025-10-13 01:54:39</p>
 
   <section>
     <h2>Ключові показники</h2>
@@ -41,17 +41,25 @@
       <div class="metric"><span>Активних доменів</span><strong>729</strong></div>
       <div class="metric"><span>Проблемні домени</span><strong>0</strong></div>
       <div class="metric"><span>Домени у deprecated</span><strong>0</strong></div>
-      <div class="metric"><span>Джерела (доменів)</span><strong>0</strong></div>
+      <div class="metric"><span>Джерела (доменів)</span><strong>334</strong></div>
     </div>
     <canvas id="historyChart" height="160" style="margin-top: 1.5rem;"></canvas>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="application/json" id="history-data">[
   {
-    "timestamp": "2025-10-12T20:55:10+00:00",
+    "timestamp": "2025-10-13T01:51:45+00:00",
     "active_domains": 729,
     "problematic_domains": 0,
     "deprecated_domains": 0,
     "sources_domains": 0,
+    "sources_problematic": 0
+  },
+  {
+    "timestamp": "2025-10-13T01:54:39+00:00",
+    "active_domains": 729,
+    "problematic_domains": 0,
+    "deprecated_domains": 0,
+    "sources_domains": 334,
     "sources_problematic": 0
   }
 ]</script>
@@ -125,32 +133,32 @@
       </thead>
       <tbody>
         
-<tr><td>ai_services.txt</td><td class="num">21</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>antivirus.txt</td><td class="num">20</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>apple.txt</td><td class="num">109</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>base.txt</td><td class="num">10</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>certificates.txt</td><td class="num">4</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>cloud_storage.txt</td><td class="num">24</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>cloudflare_warp.txt</td><td class="num">19</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>creality_print.txt</td><td class="num">14</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>ecommerce.txt</td><td class="num">7</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>educational_resources.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>extended_services.txt</td><td class="num">212</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>gaming.txt</td><td class="num">31</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>google_services.txt</td><td class="num">30</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>international_banks.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>messengers.txt</td><td class="num">11</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>microsoft_onedrive.txt</td><td class="num">49</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>microsoft_updates.txt</td><td class="num">30</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>mozilla_push.txt</td><td class="num">1</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>news_media.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>ntp_servers.txt</td><td class="num">9</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>office_collaboration.txt</td><td class="num">6</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>smart_home_devices.txt</td><td class="num">16</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>social_networks.txt</td><td class="num">9</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>streaming_services.txt</td><td class="num">10</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>ukrainian_services.txt</td><td class="num">59</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
-<tr><td>web_resources.txt</td><td class="num">13</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:48:01</td></tr>
+<tr><td>ai_services.txt</td><td class="num">21</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>antivirus.txt</td><td class="num">20</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>apple.txt</td><td class="num">109</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>base.txt</td><td class="num">10</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>certificates.txt</td><td class="num">4</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>cloud_storage.txt</td><td class="num">24</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>cloudflare_warp.txt</td><td class="num">19</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>creality_print.txt</td><td class="num">14</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>ecommerce.txt</td><td class="num">7</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>educational_resources.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>extended_services.txt</td><td class="num">212</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>gaming.txt</td><td class="num">31</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>google_services.txt</td><td class="num">30</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>international_banks.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>messengers.txt</td><td class="num">11</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>microsoft_onedrive.txt</td><td class="num">49</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>microsoft_updates.txt</td><td class="num">30</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>mozilla_push.txt</td><td class="num">1</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>news_media.txt</td><td class="num">5</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>ntp_servers.txt</td><td class="num">9</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>office_collaboration.txt</td><td class="num">6</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>smart_home_devices.txt</td><td class="num">16</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>social_networks.txt</td><td class="num">9</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>streaming_services.txt</td><td class="num">10</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>ukrainian_services.txt</td><td class="num">59</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
+<tr><td>web_resources.txt</td><td class="num">13</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-12 20:27:14</td></tr>
       </tbody>
     </table>
   </section>
@@ -163,8 +171,8 @@
       </thead>
       <tbody>
         
-<tr><td>anudeep_whitelist</td><td><a href="https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt" target="_blank" rel="noopener">https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt</a></td><td class="num">0</td><td class="num">0</td><td class="num">0%</td><td>немає даних</td></tr>
-<tr><td>anudeep_optional</td><td><a href="https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt" target="_blank" rel="noopener">https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt</a></td><td class="num">0</td><td class="num">0</td><td class="num">0%</td><td>немає даних</td></tr>
+<tr><td>anudeep_whitelist</td><td><a href="https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt" target="_blank" rel="noopener">https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt</a></td><td class="num">191</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-13 01:52:02</td></tr>
+<tr><td>anudeep_optional</td><td><a href="https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt" target="_blank" rel="noopener">https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt</a></td><td class="num">143</td><td class="num">0</td><td class="num">0.0%</td><td>2025-10-13 01:52:03</td></tr>
       </tbody>
     </table>
   </section>
@@ -177,7 +185,7 @@
   </section>
 
   <footer>
-    Звіт сформовано скриптом generate_stats_report.sh • 2025-10-12 20:55:10 UTC
+    Звіт сформовано скриптом generate_stats_report.sh • 2025-10-13 01:54:39 UTC
   </footer>
 </body>
 </html>

--- a/docs/data_history.json
+++ b/docs/data_history.json
@@ -1,10 +1,18 @@
 [
   {
-    "timestamp": "2025-10-12T20:55:10+00:00",
+    "timestamp": "2025-10-13T01:51:45+00:00",
     "active_domains": 729,
     "problematic_domains": 0,
     "deprecated_domains": 0,
     "sources_domains": 0,
+    "sources_problematic": 0
+  },
+  {
+    "timestamp": "2025-10-13T01:54:39+00:00",
+    "active_domains": 729,
+    "problematic_domains": 0,
+    "deprecated_domains": 0,
+    "sources_domains": 334,
     "sources_problematic": 0
   }
 ]

--- a/docs/data_stats.en.md
+++ b/docs/data_stats.en.md
@@ -2,37 +2,37 @@
 
 > Ukrainian version: [docs/data_stats.md](data_stats.md)
 
-Updated: 2025-10-12 20:55:07
+Updated: 2025-10-13 01:54:39
 
 ## Categories
 | Category | Active domains | Problematic | Unavailable share | Last check |
 | --- | ---: | ---: | ---: | --- |
-| ai_services.txt | 21 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| antivirus.txt | 20 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| apple.txt | 109 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| base.txt | 10 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| certificates.txt | 4 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| cloud_storage.txt | 24 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| cloudflare_warp.txt | 19 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| creality_print.txt | 14 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ecommerce.txt | 7 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| educational_resources.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| extended_services.txt | 212 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| gaming.txt | 31 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| google_services.txt | 30 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| international_banks.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| messengers.txt | 11 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| microsoft_onedrive.txt | 49 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| microsoft_updates.txt | 30 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| mozilla_push.txt | 1 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| news_media.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ntp_servers.txt | 9 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| office_collaboration.txt | 6 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| smart_home_devices.txt | 16 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| social_networks.txt | 9 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| streaming_services.txt | 10 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ukrainian_services.txt | 59 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| web_resources.txt | 13 | 0 | 0.0% | 2025-10-12 20:48:01 |
+| ai_services.txt | 21 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| antivirus.txt | 20 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| apple.txt | 109 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| base.txt | 10 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| certificates.txt | 4 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| cloud_storage.txt | 24 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| cloudflare_warp.txt | 19 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| creality_print.txt | 14 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ecommerce.txt | 7 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| educational_resources.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| extended_services.txt | 212 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| gaming.txt | 31 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| google_services.txt | 30 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| international_banks.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| messengers.txt | 11 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| microsoft_onedrive.txt | 49 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| microsoft_updates.txt | 30 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| mozilla_push.txt | 1 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| news_media.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ntp_servers.txt | 9 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| office_collaboration.txt | 6 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| smart_home_devices.txt | 16 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| social_networks.txt | 9 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| streaming_services.txt | 10 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ukrainian_services.txt | 59 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| web_resources.txt | 13 | 0 | 0.0% | 2025-10-12 20:27:14 |
 
 ### Notes
 * “Problematic” = domains that failed verification or were moved to `deprecated.txt`.
@@ -41,11 +41,11 @@ Updated: 2025-10-12 20:55:07
 ## External sources
 | Source | URL | Domains | Problematic | Unavailable share | Last update |
 | --- | --- | ---: | ---: | ---: | --- |
-| anudeep_whitelist | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | 0 | 0 | 0% | no data |
-| anudeep_optional | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt | 0 | 0 | 0% | no data |
+| anudeep_whitelist | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | 191 | 0 | 0.0% | 2025-10-13 01:52:02 |
+| anudeep_optional | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt | 143 | 0 | 0.0% | 2025-10-13 01:52:03 |
 
 ## Aggregated metrics
 * Active domains across categories: 729.
 * Problematic domains in categories (status + deprecated): 0.
 * Domains in `deprecated.txt`: 0.
-* Domains in combined external sources: 0 (problematic: 0).
+* Domains in combined external sources: 334 (problematic: 0).

--- a/docs/data_stats.md
+++ b/docs/data_stats.md
@@ -2,37 +2,37 @@
 
 > English version: [docs/data_stats.en.md](data_stats.en.md)
 
-Оновлено: 2025-10-12 20:55:07
+Оновлено: 2025-10-13 01:54:31
 
 ## Категорії
 | Категорія | Активних доменів | Проблемні | Частка недоступних | Остання перевірка |
 | --- | ---: | ---: | ---: | --- |
-| ai_services.txt | 21 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| antivirus.txt | 20 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| apple.txt | 109 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| base.txt | 10 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| certificates.txt | 4 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| cloud_storage.txt | 24 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| cloudflare_warp.txt | 19 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| creality_print.txt | 14 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ecommerce.txt | 7 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| educational_resources.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| extended_services.txt | 212 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| gaming.txt | 31 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| google_services.txt | 30 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| international_banks.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| messengers.txt | 11 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| microsoft_onedrive.txt | 49 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| microsoft_updates.txt | 30 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| mozilla_push.txt | 1 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| news_media.txt | 5 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ntp_servers.txt | 9 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| office_collaboration.txt | 6 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| smart_home_devices.txt | 16 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| social_networks.txt | 9 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| streaming_services.txt | 10 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| ukrainian_services.txt | 59 | 0 | 0.0% | 2025-10-12 20:48:01 |
-| web_resources.txt | 13 | 0 | 0.0% | 2025-10-12 20:48:01 |
+| ai_services.txt | 21 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| antivirus.txt | 20 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| apple.txt | 109 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| base.txt | 10 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| certificates.txt | 4 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| cloud_storage.txt | 24 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| cloudflare_warp.txt | 19 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| creality_print.txt | 14 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ecommerce.txt | 7 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| educational_resources.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| extended_services.txt | 212 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| gaming.txt | 31 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| google_services.txt | 30 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| international_banks.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| messengers.txt | 11 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| microsoft_onedrive.txt | 49 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| microsoft_updates.txt | 30 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| mozilla_push.txt | 1 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| news_media.txt | 5 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ntp_servers.txt | 9 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| office_collaboration.txt | 6 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| smart_home_devices.txt | 16 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| social_networks.txt | 9 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| streaming_services.txt | 10 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| ukrainian_services.txt | 59 | 0 | 0.0% | 2025-10-12 20:27:14 |
+| web_resources.txt | 13 | 0 | 0.0% | 2025-10-12 20:27:14 |
 
 ### Пояснення
 * "Проблемні" = домени, що мають невдалий стан перевірки або були перенесені до `deprecated.txt`.
@@ -41,11 +41,11 @@
 ## Зовнішні джерела
 | Джерело | URL | Доменів | Проблемні | Частка недоступних | Останнє оновлення |
 | --- | --- | ---: | ---: | ---: | --- |
-| anudeep_whitelist | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | 0 | 0 | 0% | немає даних |
-| anudeep_optional | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt | 0 | 0 | 0% | немає даних |
+| anudeep_whitelist | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | 191 | 0 | 0.0% | 2025-10-13 01:52:02 |
+| anudeep_optional | https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt | 143 | 0 | 0.0% | 2025-10-13 01:52:03 |
 
 ## Агреговані показники
 * Активних доменів у категоріях: 729.
 * Проблемних доменів у категоріях (стан + deprecated): 0.
 * Домени у deprecated.txt: 0.
-* Домени у зведених джерелах: 0 (з них проблемних 0).
+* Домени у зведених джерелах: 334 (з них проблемних 0).


### PR DESCRIPTION
**Опис змін:**
- розширено generate_stats_report.sh генерацією англомовного markdown-звіту та повторним використанням даних таблиць;
- актуалізовано HTML-дашборд, історію показників і markdown-звіти після завантаження зовнішніх whitelist-джерел;
- забезпечено автоматичний вибір шляху для англомовного звіту під час тестів.

**Тип зміни:** feat

**Посилання на задачу/квиток:** #ROADMAP

**Перевірки:**
- [x] юніт-тести додано/оновлено (якщо змінено логіку);
- [x] локально пройшли тести та лінтери;
- [x] немає секретів/ключів у дифі;
- [x] немає неконтрольованих великих видалень без пояснення.

**Вплив:** немає змін API чи вимог до сумісності.

**Скрін/лог/профіль (за потреби):** не потрібно.

------
https://chatgpt.com/codex/tasks/task_e_68ec5b0ed194832e978fac428bdbe087