### PR TITLE
Додано скрипт аналітики доменів та звіт

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,6 +103,21 @@ INCLUDE_EXTERNAL_SOURCES=0 ./generate_whitelist.sh
 SOURCES_COMBINED=custom.txt ./generate_whitelist.sh
 ```
 
+## Domain analytics
+
+Use the `analyze_domains.py` script to examine how categories are structured. It counts domains per category, highlights
+duplicates across files, and builds a TLD distribution report.
+
+```bash
+./analyze_domains.py               # writes docs/domain_analysis.md plus a JSON snapshot
+DOMAIN_ANALYSIS_OUTPUT=custom.md \
+DOMAIN_ANALYSIS_JSON=stats.json \
+./analyze_domains.py --stdout     # custom paths and console output
+```
+
+Reports are available as Markdown (`docs/domain_analysis.md`) and JSON (`docs/domain_analysis.json`) so they can be reused in CI
+pipelines or dashboards.
+
 ## Usage
 
 1. Copy `whitelist.txt` to your pihole server.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ OUTFILE=exports/custom.txt ./generate_whitelist.sh              # альтерн
 
 Сформований файл одразу готовий до імпорту в pihole. Якщо вказати шлях із підкаталогами, вони будуть створені автоматично.
 
+## Аналітика доменів
+
+Для огляду структури списків використовуйте скрипт `analyze_domains.py`. Він підраховує кількість доменів у кожній категорії,
+виявляє дублікати між файлами та формує звіт із розподілом за TLD.
+
+```bash
+./analyze_domains.py               # звіт у docs/domain_analysis.md та JSON-версія
+DOMAIN_ANALYSIS_OUTPUT=custom.md \
+DOMAIN_ANALYSIS_JSON=stats.json \
+./analyze_domains.py --stdout     # кастомні шляхи та вивід у консоль
+```
+
+Підсумки доступні у форматах Markdown (`docs/domain_analysis.md`) та JSON (`docs/domain_analysis.json`), що зручно для
+подальшої інтеграції у CI або дашборди.
+
 ## Зовнішні джерела доменів
 
 Щоб не шукати вручну додаткові домени для білого списку, скористайтеся

--- a/analyze_domains.py
+++ b/analyze_domains.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Звіт з аналітики доменів для списків білого списку Pi-hole.
+
+Скрипт читає файли категорій, обчислює агреговані метрики та формує
+Markdown-звіт із ключовими показниками, розподілом за категоріями,
+TLD і базовими доменами. Дублікати між категоріями відображаються
+окремим розділом.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime as _dt
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Counter, Dict, Iterable, List, Mapping, Sequence, Set, Tuple
+
+DEFAULT_CATEGORIES_DIR = "categories"
+DEFAULT_WHITELIST_FILE = "whitelist.txt"
+DEFAULT_OUTPUT_FILE = "docs/domain_analysis.md"
+DEFAULT_JSON_OUTPUT = "docs/domain_analysis.json"
+
+
+@dataclass(frozen=True)
+class DomainRecord:
+    domain: str
+    category: str
+
+
+@dataclass
+class CategoryStats:
+    name: str
+    total: int
+    unique: int
+    duplicates: int
+    tld_counter: Counter[str]
+
+    @property
+    def unique_ratio(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return self.unique / self.total
+
+    def top_tlds(self, limit: int = 3) -> List[Tuple[str, int]]:
+        return sorted(self.tld_counter.items(), key=lambda item: (-item[1], item[0]))[:limit]
+
+
+class DomainAnalyzer:
+    def __init__(
+        self,
+        categories_dir: Path,
+        whitelist_file: Path | None,
+    ) -> None:
+        self.categories_dir = categories_dir
+        self.whitelist_file = whitelist_file
+        self._category_files: List[Path] = []
+
+    def _iter_category_files(self) -> Iterable[Path]:
+        if not self.categories_dir.is_dir():
+            return []
+        if not self._category_files:
+            excluded = {"deprecated.txt", "comment_allowlist.txt"}
+            files = [
+                path
+                for path in self.categories_dir.rglob("*.txt")
+                if path.is_file() and path.name not in excluded
+            ]
+            self._category_files = sorted(files)
+        return self._category_files
+
+    @staticmethod
+    def _clean_domain(line: str) -> str | None:
+        line = line.strip()
+        if not line:
+            return None
+        if line.startswith("#"):
+            return None
+        if "#" in line:
+            line = line.split("#", 1)[0].strip()
+        if not line:
+            return None
+        return line
+
+    @staticmethod
+    def _tld(domain: str) -> str:
+        if "." not in domain:
+            return domain.lower()
+        return domain.rsplit(".", 1)[-1].lower()
+
+    @staticmethod
+    def _base_domain(domain: str) -> str:
+        parts = domain.lower().split(".")
+        if len(parts) < 2:
+            return domain.lower()
+        return ".".join(parts[-2:])
+
+    def read_categories(self) -> Tuple[List[DomainRecord], Dict[str, CategoryStats]]:
+        records: List[DomainRecord] = []
+        per_category: Dict[str, CategoryStats] = {}
+        for file_path in self._iter_category_files():
+            category_name = file_path.name
+            domains: List[str] = []
+            tld_counter: Counter[str] = collections.Counter()
+            seen: Set[str] = set()
+            duplicates = 0
+            with file_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    domain = self._clean_domain(line)
+                    if domain is None:
+                        continue
+                    domains.append(domain)
+                    tld_counter[self._tld(domain)] += 1
+                    if domain in seen:
+                        duplicates += 1
+                    else:
+                        seen.add(domain)
+                        records.append(DomainRecord(domain=domain, category=category_name))
+            stats = CategoryStats(
+                name=category_name,
+                total=len(domains),
+                unique=len(seen),
+                duplicates=duplicates,
+                tld_counter=tld_counter,
+            )
+            per_category[category_name] = stats
+        return records, per_category
+
+    def read_whitelist(self) -> Set[str]:
+        if not self.whitelist_file:
+            return set()
+        if not self.whitelist_file.exists():
+            return set()
+        domains: Set[str] = set()
+        with self.whitelist_file.open("r", encoding="utf-8") as handle:
+            for raw in handle:
+                domain = self._clean_domain(raw)
+                if domain is None:
+                    continue
+                domains.add(domain)
+        return domains
+
+
+def format_percentage(value: float) -> str:
+    if value <= 0:
+        return "0.0%"
+    return f"{value * 100:.1f}%"
+
+
+def render_markdown(
+    summary: Mapping[str, int],
+    category_stats: Sequence[CategoryStats],
+    tld_counts: Mapping[str, int],
+    base_domain_counts: Mapping[str, int],
+    duplicates: Mapping[str, Sequence[str]],
+    whitelist_summary: Mapping[str, int],
+    generated_at: _dt.datetime,
+) -> str:
+    lines: List[str] = []
+    lines.append("# Аналітика доменів")
+    lines.append("")
+    timezone_label = generated_at.strftime("%Z")
+    timestamp = generated_at.strftime("%Y-%m-%d %H:%M:%S")
+    if timezone_label:
+        lines.append(f"Оновлено: {timestamp} {timezone_label}")
+    else:
+        lines.append(f"Оновлено: {generated_at.isoformat()}")
+    lines.append("")
+    lines.append("## Коротке зведення")
+    lines.append("")
+    lines.append(f"- Категорій проаналізовано: {summary['categories']}.")
+    lines.append(f"- Записів у категоріях (з повторами): {summary['total_records']}.")
+    share = summary['unique_domains'] / max(summary['total_records'], 1)
+    lines.append(
+        "- Унікальних доменів у категоріях: "
+        f"{summary['unique_domains']} ({format_percentage(share)} від загальної кількості записів)."
+    )
+    lines.append(
+        f"- Домени, що зустрічаються в кількох категоріях: {summary['multi_category_domains']}."
+    )
+    if whitelist_summary:
+        lines.append(
+            f"- Унікальних доменів у whitelist.txt: {whitelist_summary['unique_whitelist']}."
+        )
+        lines.append(
+            "- Доменів поза категоріями, але присутніх у whitelist.txt: "
+            f"{whitelist_summary['only_in_whitelist']}."
+        )
+        examples = whitelist_summary.get("only_in_whitelist_examples", [])
+        if examples:
+            preview = ", ".join(examples[:5])
+            lines.append(
+                "- Приклади доменів, що є лише у whitelist.txt: "
+                f"{preview}."
+            )
+    lines.append("")
+
+    lines.append("## Розподіл за категоріями")
+    lines.append("")
+    if not category_stats:
+        lines.append("Немає доступних категорій для аналізу.")
+    else:
+        lines.append("| Категорія | Записів | Унікальних | Повторів | Частка унікальних | Топ TLD |")
+        lines.append("| --- | ---: | ---: | ---: | ---: | --- |")
+        for stats in sorted(category_stats, key=lambda item: item.name):
+            top_tld_str = ", ".join(
+                f"{tld} ({count})" for tld, count in stats.top_tlds()
+            ) or "—"
+            lines.append(
+                f"| {stats.name} | {stats.total} | {stats.unique} | {stats.duplicates} | "
+                f"{format_percentage(stats.unique_ratio)} | {top_tld_str} |"
+            )
+    lines.append("")
+
+    lines.append("## Розподіл за TLD")
+    lines.append("")
+    if not tld_counts:
+        lines.append("Немає даних про TLD.")
+    else:
+        total_unique = sum(tld_counts.values())
+        lines.append("| TLD | Доменів | Частка |")
+        lines.append("| --- | ---: | ---: |")
+        for tld, count in sorted(tld_counts.items(), key=lambda item: (-item[1], item[0])):
+            share = format_percentage(count / max(total_unique, 1))
+            lines.append(f"| .{tld} | {count} | {share} |")
+    lines.append("")
+
+    lines.append("## Найпоширеніші базові домени")
+    lines.append("")
+    if not base_domain_counts:
+        lines.append("Не вдалося визначити базові домени.")
+    else:
+        lines.append("| Базовий домен | Кількість піддоменів |")
+        lines.append("| --- | ---: |")
+        for domain, count in sorted(base_domain_counts.items(), key=lambda item: (-item[1], item[0]))[:15]:
+            lines.append(f"| {domain} | {count} |")
+    lines.append("")
+
+    lines.append("## Дублікати між категоріями")
+    lines.append("")
+    if not duplicates:
+        lines.append("Доменів, що дублюються між категоріями, не виявлено.")
+    else:
+        lines.append("| Домен | Категорії |")
+        lines.append("| --- | --- |")
+        for domain, cats in sorted(duplicates.items()):
+            joined = ", ".join(sorted(cats))
+            lines.append(f"| {domain} | {joined} |")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_json(
+    summary: Mapping[str, int],
+    category_stats: Mapping[str, Mapping[str, int]],
+    tld_counts: Mapping[str, int],
+    base_domains: Mapping[str, int],
+    duplicates: Mapping[str, Sequence[str]],
+    whitelist_summary: Mapping[str, int],
+    generated_at: _dt.datetime,
+) -> str:
+    payload = {
+        "generated_at": generated_at.isoformat(),
+        "summary": summary,
+        "categories": category_stats,
+        "tld": dict(tld_counts),
+        "base_domains": dict(base_domains),
+        "duplicates": {key: list(value) for key, value in duplicates.items()},
+        "whitelist": whitelist_summary,
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Аналітика доменів за категоріями")
+    parser.add_argument(
+        "--categories",
+        dest="categories",
+        default=os.environ.get("CATEGORIES_DIR", DEFAULT_CATEGORIES_DIR),
+        help="Каталог із файлами категорій",
+    )
+    parser.add_argument(
+        "--whitelist",
+        dest="whitelist",
+        default=os.environ.get("WHITELIST_FILE", DEFAULT_WHITELIST_FILE),
+        help="Файл whitelist.txt для порівняння (опційно)",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        default=os.environ.get("DOMAIN_ANALYSIS_OUTPUT", DEFAULT_OUTPUT_FILE),
+        help="Markdown-звіт для збереження",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        default=os.environ.get("DOMAIN_ANALYSIS_JSON", DEFAULT_JSON_OUTPUT),
+        help="JSON-файл зі статистикою",
+    )
+    parser.add_argument(
+        "--stdout", action="store_true", help="Вивести результат у stdout замість запису у файл"
+    )
+
+    args = parser.parse_args()
+
+    categories_dir = Path(args.categories)
+    whitelist_path = Path(args.whitelist) if args.whitelist else None
+    analyzer = DomainAnalyzer(categories_dir=categories_dir, whitelist_file=whitelist_path)
+
+    records, per_category = analyzer.read_categories()
+    whitelist_domains = analyzer.read_whitelist()
+
+    domain_to_categories: Dict[str, Set[str]] = collections.defaultdict(set)
+    for record in records:
+        domain_to_categories[record.domain].add(record.category)
+
+    unique_domains = set(domain_to_categories.keys())
+
+    tld_counts: Dict[str, int] = collections.Counter()
+    base_domain_counts: Dict[str, int] = collections.Counter()
+    for domain in unique_domains:
+        tld_counts[DomainAnalyzer._tld(domain)] += 1
+        base_domain_counts[DomainAnalyzer._base_domain(domain)] += 1
+
+    duplicates: Dict[str, Sequence[str]] = {
+        domain: sorted(categories)
+        for domain, categories in domain_to_categories.items()
+        if len(categories) > 1
+    }
+
+    summary = {
+        "categories": len(per_category),
+        "total_records": sum(stats.total for stats in per_category.values()),
+        "unique_domains": len(unique_domains),
+        "multi_category_domains": len(duplicates),
+    }
+
+    whitelist_summary: Dict[str, int] = {}
+    if whitelist_domains:
+        only_in_whitelist = whitelist_domains - unique_domains
+        only_in_list = sorted(only_in_whitelist)
+        whitelist_summary = {
+            "unique_whitelist": len(whitelist_domains),
+            "only_in_whitelist": len(only_in_whitelist),
+            "only_in_whitelist_examples": only_in_list[:10],
+        }
+
+    generated_at = _dt.datetime.now(tz=_dt.timezone.utc).astimezone()
+
+    markdown = render_markdown(
+        summary=summary,
+        category_stats=list(per_category.values()),
+        tld_counts=tld_counts,
+        base_domain_counts=base_domain_counts,
+        duplicates=duplicates,
+        whitelist_summary=whitelist_summary,
+        generated_at=generated_at,
+    )
+
+    json_payload = render_json(
+        summary=summary,
+        category_stats={
+            name: {
+                "total": stats.total,
+                "unique": stats.unique,
+                "duplicates": stats.duplicates,
+            }
+            for name, stats in per_category.items()
+        },
+        tld_counts=tld_counts,
+        base_domains=base_domain_counts,
+        duplicates=duplicates,
+        whitelist_summary=whitelist_summary,
+        generated_at=generated_at,
+    )
+
+    if args.stdout:
+        print(markdown)
+    else:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(markdown, encoding="utf-8")
+
+    json_path = Path(args.json_output)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json_payload, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/domain_analysis.json
+++ b/docs/domain_analysis.json
@@ -1,0 +1,572 @@
+{
+  "generated_at": "2025-10-21T18:13:30.741551+00:00",
+  "summary": {
+    "categories": 26,
+    "total_records": 738,
+    "unique_domains": 707,
+    "multi_category_domains": 29
+  },
+  "categories": {
+    "ai_services.txt": {
+      "total": 21,
+      "unique": 21,
+      "duplicates": 0
+    },
+    "antivirus.txt": {
+      "total": 20,
+      "unique": 20,
+      "duplicates": 0
+    },
+    "apple.txt": {
+      "total": 109,
+      "unique": 109,
+      "duplicates": 0
+    },
+    "base.txt": {
+      "total": 10,
+      "unique": 10,
+      "duplicates": 0
+    },
+    "certificates.txt": {
+      "total": 4,
+      "unique": 4,
+      "duplicates": 0
+    },
+    "cloud_storage.txt": {
+      "total": 24,
+      "unique": 24,
+      "duplicates": 0
+    },
+    "cloudflare_warp.txt": {
+      "total": 19,
+      "unique": 19,
+      "duplicates": 0
+    },
+    "creality_print.txt": {
+      "total": 14,
+      "unique": 14,
+      "duplicates": 0
+    },
+    "ecommerce.txt": {
+      "total": 7,
+      "unique": 7,
+      "duplicates": 0
+    },
+    "educational_resources.txt": {
+      "total": 5,
+      "unique": 5,
+      "duplicates": 0
+    },
+    "extended_services.txt": {
+      "total": 216,
+      "unique": 216,
+      "duplicates": 0
+    },
+    "gaming.txt": {
+      "total": 31,
+      "unique": 31,
+      "duplicates": 0
+    },
+    "google_services.txt": {
+      "total": 30,
+      "unique": 30,
+      "duplicates": 0
+    },
+    "international_banks.txt": {
+      "total": 5,
+      "unique": 5,
+      "duplicates": 0
+    },
+    "messengers.txt": {
+      "total": 11,
+      "unique": 11,
+      "duplicates": 0
+    },
+    "microsoft_onedrive.txt": {
+      "total": 49,
+      "unique": 49,
+      "duplicates": 0
+    },
+    "microsoft_updates.txt": {
+      "total": 31,
+      "unique": 31,
+      "duplicates": 0
+    },
+    "mozilla_push.txt": {
+      "total": 1,
+      "unique": 1,
+      "duplicates": 0
+    },
+    "news_media.txt": {
+      "total": 5,
+      "unique": 5,
+      "duplicates": 0
+    },
+    "ntp_servers.txt": {
+      "total": 9,
+      "unique": 9,
+      "duplicates": 0
+    },
+    "office_collaboration.txt": {
+      "total": 6,
+      "unique": 6,
+      "duplicates": 0
+    },
+    "smart_home_devices.txt": {
+      "total": 16,
+      "unique": 16,
+      "duplicates": 0
+    },
+    "social_networks.txt": {
+      "total": 9,
+      "unique": 9,
+      "duplicates": 0
+    },
+    "streaming_services.txt": {
+      "total": 10,
+      "unique": 10,
+      "duplicates": 0
+    },
+    "ukrainian_services.txt": {
+      "total": 63,
+      "unique": 63,
+      "duplicates": 0
+    },
+    "web_resources.txt": {
+      "total": 13,
+      "unique": 13,
+      "duplicates": 0
+    }
+  },
+  "tld": {
+    "com": 500,
+    "us": 5,
+    "co": 2,
+    "org": 25,
+    "it": 1,
+    "ua": 64,
+    "ai": 6,
+    "net": 75,
+    "ms": 4,
+    "nz": 4,
+    "eu": 7,
+    "is": 1,
+    "me": 2,
+    "io": 2,
+    "tv": 2,
+    "media": 1,
+    "app": 1,
+    "one": 1,
+    "goog": 1,
+    "gov": 1,
+    "google": 1,
+    "in": 1
+  },
+  "base_domains": {
+    "apple.com": 102,
+    "zoom.us": 2,
+    "eyecon-app.com": 2,
+    "facebook.com": 28,
+    "wgcdn.co": 1,
+    "bitdefender.com": 2,
+    "spotify.com": 4,
+    "pinterest.com": 3,
+    "icloud.com": 2,
+    "microsoft365.com": 1,
+    "cloudflareclient.com": 4,
+    "messenger.com": 4,
+    "khanacademy.org": 1,
+    "redd.it": 1,
+    "github.com": 3,
+    "com.ua": 7,
+    "digicert.com": 2,
+    "gov.ua": 22,
+    "steamcontent.com": 1,
+    "tiktokw.us": 1,
+    "mistral.ai": 1,
+    "ntp.org": 3,
+    "redditstatic.com": 1,
+    "cloudflare.com": 12,
+    "whatsapp.com": 1,
+    "tiktokcdn.com": 1,
+    "norton.com": 1,
+    "creality.com": 6,
+    "discord.com": 1,
+    "telegram.org": 4,
+    "microsoft.com": 26,
+    "adguard-dns.com": 1,
+    "steamcommunity.com": 1,
+    "yitechnology.com": 1,
+    "geforce.com": 1,
+    "mycrealitycloud.com": 7,
+    "byteoversea.com": 1,
+    "amazonaws.com": 2,
+    "fb.com": 1,
+    "privatbank.ua": 3,
+    "windows.net": 4,
+    "googleapis.com": 12,
+    "pb.ua": 1,
+    "googlevideo.com": 2,
+    "fbcdn.net": 22,
+    "live.com": 16,
+    "huggingface.co": 1,
+    "xboxlive.com": 15,
+    "onestore.ms": 1,
+    "windowsupdate.com": 2,
+    "google.com": 25,
+    "tuyaeu.com": 1,
+    "msn.com": 2,
+    "youtube.com": 3,
+    "msftconnecttest.com": 1,
+    "x.com": 1,
+    "ttoversea.net": 1,
+    "chatgpt.com": 1,
+    "mega.nz": 2,
+    "snapchat.com": 1,
+    "capcutapi.com": 1,
+    "wargaming.net": 6,
+    "cdn-apple.com": 6,
+    "openai.com": 4,
+    "dropbox.com": 4,
+    "org.ua": 1,
+    "ukrposhta.ua": 4,
+    "virtualearth.net": 4,
+    "tiktokd.org": 1,
+    "live.net": 10,
+    "gog.com": 1,
+    "hotmail.com": 1,
+    "paypal.com": 1,
+    "symcb.com": 2,
+    "jsdelivr.net": 1,
+    "monobank.ua": 5,
+    "mi.com": 1,
+    "worldoftanks.eu": 4,
+    "xiaomi.net": 8,
+    "adguard.com": 3,
+    "tiktokw.eu": 1,
+    "clamav.net": 1,
+    "crealitycloud.com": 1,
+    "windows.com": 2,
+    "microsoftonline.com": 2,
+    "cdninstagram.com": 3,
+    "eset.com": 3,
+    "alibaba.com": 1,
+    "googletagmanager.com": 1,
+    "signal.org": 9,
+    "akamaihd.net": 2,
+    "time.is": 1,
+    "sophos.com": 1,
+    "wotblitz.com": 1,
+    "raiffeisen.ua": 3,
+    "hbomax.com": 1,
+    "gvt1.com": 1,
+    "fb.me": 1,
+    "gstatic.com": 4,
+    "malwarebytes.com": 2,
+    "fabric.io": 1,
+    "anthropic.com": 1,
+    "passport.net": 1,
+    "reddit.com": 1,
+    "capcutapi.us": 1,
+    "msftncsi.com": 4,
+    "tiktokv.com": 1,
+    "skype.com": 3,
+    "avast.com": 1,
+    "twitter.com": 4,
+    "snssdk.com": 1,
+    "fastly.net": 1,
+    "steampowered.com": 2,
+    "c-wss.com": 1,
+    "ys7.com": 2,
+    "sportbank.ua": 2,
+    "omtrdc.net": 1,
+    "office.com": 3,
+    "oschadbank.ua": 2,
+    "cloudflare-dns.com": 2,
+    "mcafee.com": 2,
+    "xiaoyi.com": 2,
+    "googleusercontent.com": 2,
+    "mozilla.com": 1,
+    "espreso.tv": 1,
+    "freepik.com": 1,
+    "adobe.com": 1,
+    "instagram.com": 5,
+    "axm-usercontent-apple.com": 1,
+    "prom.ua": 2,
+    "wotblitz.eu": 1,
+    "coursera.org": 1,
+    "riotgames.com": 1,
+    "gamepass.com": 1,
+    "linkedin.com": 1,
+    "revolut.com": 1,
+    "suspilne.media": 1,
+    "nsatc.net": 1,
+    "crashlytics.com": 1,
+    "olx.ua": 1,
+    "hik-connect.com": 1,
+    "shopify.com": 1,
+    "x.ai": 1,
+    "akadns.net": 2,
+    "replicate.com": 1,
+    "tuya.com": 1,
+    "poe.com": 1,
+    "soundcloud.com": 1,
+    "leagueoflegends.com": 1,
+    "textsecure-service-whispersystems.org": 1,
+    "wise.com": 1,
+    "pandasecurity.com": 2,
+    "tiktokv.us": 1,
+    "hulu.com": 1,
+    "avira.com": 2,
+    "dahuatech.com": 3,
+    "tiktok.tv": 1,
+    "souqcdn.com": 2,
+    "threads.net": 1,
+    "netflix.com": 1,
+    "novaposhta.ua": 4,
+    "tiktokcdn-us.com": 1,
+    "onedrive.com": 2,
+    "payoneer.com": 1,
+    "cloudfront.net": 1,
+    "mozilla.net": 1,
+    "sophosupd.com": 1,
+    "skydrive.com": 1,
+    "whispersystems.org": 2,
+    "microsoftteams.com": 2,
+    "pinimg.com": 1,
+    "claude.ai": 1,
+    "1drv.com": 1,
+    "office.net": 1,
+    "ukr.net": 1,
+    "unpkg.com": 1,
+    "fontawesome.com": 1,
+    "sfx.ms": 2,
+    "liqpay.ua": 1,
+    "ebay.com": 1,
+    "office365.com": 2,
+    "grok.com": 1,
+    "tiktok.com": 2,
+    "blizzard.com": 1,
+    "co.nz": 2,
+    "wikipedia.org": 1,
+    "disneyplus.com": 1,
+    "steam-chat.com": 1,
+    "wa.me": 1,
+    "aliexpress.com": 1,
+    "tiktokapi.com": 1,
+    "steamstatic.com": 1,
+    "facebook.net": 1,
+    "privat24.ua": 2,
+    "s-microsoft.com": 2,
+    "perplexity.ai": 1,
+    "24tv.ua": 1,
+    "byteoversea.net": 1,
+    "pumb.ua": 1,
+    "naurok.ua": 1,
+    "tiktokv-us.com": 1,
+    "stripe.com": 1,
+    "gfx.ms": 1,
+    "argotunnel.com": 1,
+    "twimg.com": 1,
+    "amazon.com": 1,
+    "slack.com": 2,
+    "ttlivecdn.com": 1,
+    "bbc.com": 1,
+    "novaposhta.com": 1,
+    "synology.com": 4,
+    "diia.app": 1,
+    "box.com": 1,
+    "tlivecdn.com": 1,
+    "livefilestore.com": 1,
+    "ttoverseaus.net": 1,
+    "cohere.ai": 1,
+    "vsassets.io": 1,
+    "hikvision.com": 1,
+    "tiktokcdn-in.com": 1,
+    "stability.ai": 1,
+    "letsencrypt.org": 1,
+    "hoyoverse.com": 1,
+    "microsoft-tst.com": 1,
+    "outlook.com": 1,
+    "redditmedia.com": 3,
+    "symantecliveupdate.com": 1,
+    "playvalorant.com": 1,
+    "one.one": 1,
+    "dahuasecurity.com": 1,
+    "pki.goog": 1,
+    "rockstargames.com": 1,
+    "apple-cloudkit.com": 1,
+    "bestbuy.com": 1,
+    "battle.net": 1,
+    "mzstatic.com": 1,
+    "fbsbx.com": 1,
+    "max.com": 1,
+    "epicgames.com": 1,
+    "edx.org": 1,
+    "android.com": 1,
+    "ty-iot.com": 1,
+    "dropboxusercontent.com": 1,
+    "xbox.com": 1,
+    "m365.com": 1,
+    "valorant.com": 1,
+    "etsy.com": 1,
+    "nist.gov": 1,
+    "primevideo.com": 1,
+    "cloudflarewarp.com": 1,
+    "playstation.com": 1,
+    "tiktokv.eu": 1,
+    "samsungapps.com": 1,
+    "githubusercontent.com": 1,
+    "paymonobank.ua": 1,
+    "mesh.com": 1,
+    "tuyaus.com": 1,
+    "symantec.com": 1,
+    "appleiphonecell.com": 1,
+    "aliyuncs.com": 1,
+    "dns.google": 1,
+    "deezer.com": 1,
+    "jquery.com": 1,
+    "cloudflareinsights.com": 1,
+    "deepseek.com": 1,
+    "oaistatic.com": 1,
+    "tiktok.in": 1,
+    "demdex.net": 1,
+    "usertrust.com": 1
+  },
+  "duplicates": {
+    "gemini.google.com": [
+      "ai_services.txt",
+      "google_services.txt"
+    ],
+    "appleid.apple.com": [
+      "apple.txt",
+      "extended_services.txt"
+    ],
+    "itunes.apple.com": [
+      "apple.txt",
+      "extended_services.txt"
+    ],
+    "captive.apple.com": [
+      "apple.txt",
+      "extended_services.txt"
+    ],
+    "www.apple.com": [
+      "apple.txt",
+      "extended_services.txt"
+    ],
+    "microsoft.com": [
+      "base.txt",
+      "microsoft_updates.txt"
+    ],
+    "cdnjs.cloudflare.com": [
+      "cloudflare_warp.txt",
+      "web_resources.txt"
+    ],
+    "android.clients.google.com": [
+      "extended_services.txt",
+      "google_services.txt"
+    ],
+    "clients2.google.com": [
+      "extended_services.txt",
+      "google_services.txt"
+    ],
+    "clients3.google.com": [
+      "extended_services.txt",
+      "google_services.txt"
+    ],
+    "clients4.google.com": [
+      "extended_services.txt",
+      "google_services.txt"
+    ],
+    "connectivitycheck.gstatic.com": [
+      "extended_services.txt",
+      "google_services.txt"
+    ],
+    "ctldl.windowsupdate.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "dl.delivery.mp.microsoft.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "g.live.com": [
+      "extended_services.txt",
+      "microsoft_onedrive.txt"
+    ],
+    "login.live.com": [
+      "extended_services.txt",
+      "microsoft_onedrive.txt",
+      "microsoft_updates.txt"
+    ],
+    "login.microsoftonline.com": [
+      "extended_services.txt",
+      "microsoft_onedrive.txt",
+      "microsoft_updates.txt"
+    ],
+    "officeclient.microsoft.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "outlook.office365.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "products.office.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "settings-win.data.microsoft.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "signal.org": [
+      "extended_services.txt",
+      "messengers.txt"
+    ],
+    "twitter.com": [
+      "extended_services.txt",
+      "social_networks.txt"
+    ],
+    "www.msftconnecttest.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "www.msftncsi.com": [
+      "extended_services.txt",
+      "microsoft_updates.txt"
+    ],
+    "fonts.googleapis.com": [
+      "google_services.txt",
+      "web_resources.txt"
+    ],
+    "fonts.gstatic.com": [
+      "google_services.txt",
+      "web_resources.txt"
+    ],
+    "time.google.com": [
+      "google_services.txt",
+      "ntp_servers.txt"
+    ],
+    "onedrive.live.com": [
+      "microsoft_onedrive.txt",
+      "microsoft_updates.txt"
+    ]
+  },
+  "whitelist": {
+    "unique_whitelist": 912,
+    "only_in_whitelist": 214,
+    "only_in_whitelist_examples": [
+      "1drv.com",
+      "2.android.pool.ntp.org",
+      "a463.w10.akamai.net",
+      "a790.w16.akamai.net",
+      "acdn.adnxs.com",
+      "activate.adobe.com",
+      "adf.ly",
+      "ae01.alicdn.com",
+      "akamaihd.net",
+      "akamaitechnologies.com"
+    ]
+  }
+}

--- a/docs/domain_analysis.md
+++ b/docs/domain_analysis.md
@@ -1,0 +1,126 @@
+# Аналітика доменів
+
+Оновлено: 2025-10-21 18:13:30 UTC
+
+## Коротке зведення
+
+- Категорій проаналізовано: 26.
+- Записів у категоріях (з повторами): 738.
+- Унікальних доменів у категоріях: 707 (95.8% від загальної кількості записів).
+- Домени, що зустрічаються в кількох категоріях: 29.
+- Унікальних доменів у whitelist.txt: 912.
+- Доменів поза категоріями, але присутніх у whitelist.txt: 214.
+- Приклади доменів, що є лише у whitelist.txt: 1drv.com, 2.android.pool.ntp.org, a463.w10.akamai.net, a790.w16.akamai.net, acdn.adnxs.com.
+
+## Розподіл за категоріями
+
+| Категорія | Записів | Унікальних | Повторів | Частка унікальних | Топ TLD |
+| --- | ---: | ---: | ---: | ---: | --- |
+| ai_services.txt | 21 | 21 | 0 | 100.0% | com (14), ai (6), co (1) |
+| antivirus.txt | 20 | 20 | 0 | 100.0% | com (19), net (1) |
+| apple.txt | 109 | 109 | 0 | 100.0% | com (109) |
+| base.txt | 10 | 10 | 0 | 100.0% | com (9), org (1) |
+| certificates.txt | 4 | 4 | 0 | 100.0% | com (3), org (1) |
+| cloud_storage.txt | 24 | 24 | 0 | 100.0% | com (12), net (8), nz (4) |
+| cloudflare_warp.txt | 19 | 19 | 0 | 100.0% | com (18), one (1) |
+| creality_print.txt | 14 | 14 | 0 | 100.0% | com (14) |
+| ecommerce.txt | 7 | 7 | 0 | 100.0% | com (7) |
+| educational_resources.txt | 5 | 5 | 0 | 100.0% | org (3), ua (2) |
+| extended_services.txt | 216 | 216 | 0 | 100.0% | com (155), net (38), org (13) |
+| gaming.txt | 31 | 31 | 0 | 100.0% | com (18), net (7), eu (5) |
+| google_services.txt | 30 | 30 | 0 | 100.0% | com (28), goog (1), google (1) |
+| international_banks.txt | 5 | 5 | 0 | 100.0% | com (5) |
+| messengers.txt | 11 | 11 | 0 | 100.0% | com (6), org (5) |
+| microsoft_onedrive.txt | 49 | 49 | 0 | 100.0% | com (28), net (17), ms (3) |
+| microsoft_updates.txt | 31 | 31 | 0 | 100.0% | com (29), ms (1), net (1) |
+| mozilla_push.txt | 1 | 1 | 0 | 100.0% | com (1) |
+| news_media.txt | 5 | 5 | 0 | 100.0% | ua (2), com (1), media (1) |
+| ntp_servers.txt | 9 | 9 | 0 | 100.0% | com (4), org (3), gov (1) |
+| office_collaboration.txt | 6 | 6 | 0 | 100.0% | com (4), us (2) |
+| smart_home_devices.txt | 16 | 16 | 0 | 100.0% | com (16) |
+| social_networks.txt | 9 | 9 | 0 | 100.0% | com (8), net (1) |
+| streaming_services.txt | 10 | 10 | 0 | 100.0% | com (10) |
+| ukrainian_services.txt | 63 | 63 | 0 | 100.0% | ua (60), app (1), com (1) |
+| web_resources.txt | 13 | 13 | 0 | 100.0% | com (11), io (1), net (1) |
+
+## Розподіл за TLD
+
+| TLD | Доменів | Частка |
+| --- | ---: | ---: |
+| .com | 500 | 70.7% |
+| .net | 75 | 10.6% |
+| .ua | 64 | 9.1% |
+| .org | 25 | 3.5% |
+| .eu | 7 | 1.0% |
+| .ai | 6 | 0.8% |
+| .us | 5 | 0.7% |
+| .ms | 4 | 0.6% |
+| .nz | 4 | 0.6% |
+| .co | 2 | 0.3% |
+| .io | 2 | 0.3% |
+| .me | 2 | 0.3% |
+| .tv | 2 | 0.3% |
+| .app | 1 | 0.1% |
+| .goog | 1 | 0.1% |
+| .google | 1 | 0.1% |
+| .gov | 1 | 0.1% |
+| .in | 1 | 0.1% |
+| .is | 1 | 0.1% |
+| .it | 1 | 0.1% |
+| .media | 1 | 0.1% |
+| .one | 1 | 0.1% |
+
+## Найпоширеніші базові домени
+
+| Базовий домен | Кількість піддоменів |
+| --- | ---: |
+| apple.com | 102 |
+| facebook.com | 28 |
+| microsoft.com | 26 |
+| google.com | 25 |
+| fbcdn.net | 22 |
+| gov.ua | 22 |
+| live.com | 16 |
+| xboxlive.com | 15 |
+| cloudflare.com | 12 |
+| googleapis.com | 12 |
+| live.net | 10 |
+| signal.org | 9 |
+| xiaomi.net | 8 |
+| com.ua | 7 |
+| mycrealitycloud.com | 7 |
+
+## Дублікати між категоріями
+
+| Домен | Категорії |
+| --- | --- |
+| android.clients.google.com | extended_services.txt, google_services.txt |
+| appleid.apple.com | apple.txt, extended_services.txt |
+| captive.apple.com | apple.txt, extended_services.txt |
+| cdnjs.cloudflare.com | cloudflare_warp.txt, web_resources.txt |
+| clients2.google.com | extended_services.txt, google_services.txt |
+| clients3.google.com | extended_services.txt, google_services.txt |
+| clients4.google.com | extended_services.txt, google_services.txt |
+| connectivitycheck.gstatic.com | extended_services.txt, google_services.txt |
+| ctldl.windowsupdate.com | extended_services.txt, microsoft_updates.txt |
+| dl.delivery.mp.microsoft.com | extended_services.txt, microsoft_updates.txt |
+| fonts.googleapis.com | google_services.txt, web_resources.txt |
+| fonts.gstatic.com | google_services.txt, web_resources.txt |
+| g.live.com | extended_services.txt, microsoft_onedrive.txt |
+| gemini.google.com | ai_services.txt, google_services.txt |
+| itunes.apple.com | apple.txt, extended_services.txt |
+| login.live.com | extended_services.txt, microsoft_onedrive.txt, microsoft_updates.txt |
+| login.microsoftonline.com | extended_services.txt, microsoft_onedrive.txt, microsoft_updates.txt |
+| microsoft.com | base.txt, microsoft_updates.txt |
+| officeclient.microsoft.com | extended_services.txt, microsoft_updates.txt |
+| onedrive.live.com | microsoft_onedrive.txt, microsoft_updates.txt |
+| outlook.office365.com | extended_services.txt, microsoft_updates.txt |
+| products.office.com | extended_services.txt, microsoft_updates.txt |
+| settings-win.data.microsoft.com | extended_services.txt, microsoft_updates.txt |
+| signal.org | extended_services.txt, messengers.txt |
+| time.google.com | google_services.txt, ntp_servers.txt |
+| twitter.com | extended_services.txt, social_networks.txt |
+| www.apple.com | apple.txt, extended_services.txt |
+| www.msftconnecttest.com | extended_services.txt, microsoft_updates.txt |
+| www.msftncsi.com | extended_services.txt, microsoft_updates.txt |
+

--- a/tests/analyze_domains_test.sh
+++ b/tests/analyze_domains_test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+mkdir -p "$workdir/categories" "$workdir/docs"
+
+cat <<'CAT1' > "$workdir/categories/alpha.txt"
+# @description: Тестова категорія А
+first.example
+shared.example
+shared.example # повтор
+third.co.uk
+CAT1
+
+cat <<'CAT2' > "$workdir/categories/beta.txt"
+# @description: Тестова категорія B
+second.example
+shared.example
+fourth.io
+CAT2
+
+cat <<'WL' > "$workdir/whitelist.txt"
+first.example
+shared.example
+extra.net
+WL
+
+CATEGORIES_DIR="$workdir/categories" \
+WHITELIST_FILE="$workdir/whitelist.txt" \
+DOMAIN_ANALYSIS_OUTPUT="$workdir/docs/report.md" \
+DOMAIN_ANALYSIS_JSON="$workdir/docs/report.json" \
+"$(pwd)/analyze_domains.py"
+
+[[ -s "$workdir/docs/report.md" ]] || { echo "Markdown-звіт не згенеровано" >&2; exit 1; }
+[[ -s "$workdir/docs/report.json" ]] || { echo "JSON-звіт не згенеровано" >&2; exit 1; }
+
+grep -q 'Категорій проаналізовано: 2' "$workdir/docs/report.md"
+grep -q 'shared.example' "$workdir/docs/report.md"
+grep -q '\.example' "$workdir/docs/report.md"
+grep -q 'extra.net' "$workdir/docs/report.md"
+grep -q 'only_in_whitelist_examples' "$workdir/docs/report.json"
+
+echo "Тест analyze_domains.py пройдено"


### PR DESCRIPTION
## Опис змін
- створено `analyze_domains.py` для побудови Markdown/JSON-звітів із кількістю доменів, TLD та дублікати між категоріями
- додано інтеграційний тест `tests/analyze_domains_test.sh` і оновлено документацію про новий інструмент
- згенеровано актуальні звіти `docs/domain_analysis.md` та `docs/domain_analysis.json`

## Тип зміни
- feat

## Посилання на задачу/квиток
- #OPS-0

## Перевірки
- [x] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- Новий допоміжний скрипт без змін поточного API; звіт використовується для моніторингу доменів.

## Скрін/лог/профіль (за потреби)
- `tests/analyze_domains_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f7cbbb4960832e9514cbc0d2d57642