### PR TITLE
feat: підтримка сортування категорій у звіті аналітики

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -115,6 +115,15 @@ DOMAIN_ANALYSIS_JSON=stats.json \
 ./analyze_domains.py --stdout     # custom paths and console output
 ```
 
+You can adjust the "Category breakdown" sorting logic:
+
+```bash
+./analyze_domains.py --category-sort total                 # sort by number of records (descending)
+./analyze_domains.py --category-sort unique --category-sort-order asc
+DOMAIN_ANALYSIS_CATEGORY_SORT=unique_ratio \
+DOMAIN_ANALYSIS_CATEGORY_SORT_ORDER=desc ./analyze_domains.py
+```
+
 Reports are available as Markdown (`docs/domain_analysis.md`) and JSON (`docs/domain_analysis.json`) so they can be reused in CI
 pipelines or dashboards.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ DOMAIN_ANALYSIS_JSON=stats.json \
 ./analyze_domains.py --stdout     # кастомні шляхи та вивід у консоль
 ```
 
+Для таблиці «Розподіл за категоріями» можна змінювати логіку сортування:
+
+```bash
+./analyze_domains.py --category-sort total                 # сортування за кількістю записів (спадно)
+./analyze_domains.py --category-sort unique --category-sort-order asc
+DOMAIN_ANALYSIS_CATEGORY_SORT=unique_ratio \
+DOMAIN_ANALYSIS_CATEGORY_SORT_ORDER=desc ./analyze_domains.py
+```
+
 Підсумки доступні у форматах Markdown (`docs/domain_analysis.md`) та JSON (`docs/domain_analysis.json`), що зручно для
 подальшої інтеграції у CI або дашборди.
 

--- a/tests/analyze_domains_test.sh
+++ b/tests/analyze_domains_test.sh
@@ -19,6 +19,8 @@ cat <<'CAT2' > "$workdir/categories/beta.txt"
 second.example
 shared.example
 fourth.io
+fifth.dev
+sixth.app
 CAT2
 
 cat <<'WL' > "$workdir/whitelist.txt"
@@ -36,10 +38,33 @@ DOMAIN_ANALYSIS_JSON="$workdir/docs/report.json" \
 [[ -s "$workdir/docs/report.md" ]] || { echo "Markdown-звіт не згенеровано" >&2; exit 1; }
 [[ -s "$workdir/docs/report.json" ]] || { echo "JSON-звіт не згенеровано" >&2; exit 1; }
 
+DOMAIN_ANALYSIS_CATEGORY_SORT="total" \
+DOMAIN_ANALYSIS_CATEGORY_SORT_ORDER="desc" \
+DOMAIN_ANALYSIS_OUTPUT="$workdir/docs/report_sorted.md" \
+DOMAIN_ANALYSIS_JSON="$workdir/docs/report_sorted.json" \
+CATEGORIES_DIR="$workdir/categories" \
+WHITELIST_FILE="$workdir/whitelist.txt" \
+"$(pwd)/analyze_domains.py"
+
+[[ -s "$workdir/docs/report_sorted.md" ]] || { echo "Markdown-звіт зі сортуванням не згенеровано" >&2; exit 1; }
+
 grep -q 'Категорій проаналізовано: 2' "$workdir/docs/report.md"
 grep -q 'shared.example' "$workdir/docs/report.md"
 grep -q '\.example' "$workdir/docs/report.md"
 grep -q 'extra.net' "$workdir/docs/report.md"
 grep -q 'only_in_whitelist_examples' "$workdir/docs/report.json"
+
+beta_line=$(grep -n '| beta.txt |' "$workdir/docs/report_sorted.md" | cut -d: -f1)
+alpha_line=$(grep -n '| alpha.txt |' "$workdir/docs/report_sorted.md" | cut -d: -f1)
+
+if [[ -z "$beta_line" || -z "$alpha_line" ]]; then
+  echo "Не знайдено рядки таблиці категорій у відсортованому звіті" >&2
+  exit 1
+fi
+
+if (( beta_line >= alpha_line )); then
+  echo "Сортування категорій за total не працює" >&2
+  exit 1
+fi
 
 echo "Тест analyze_domains.py пройдено"


### PR DESCRIPTION
## Опис змін
- додано налаштування сортування категорій у analyze_domains.py та винесено логіку підготовки списку категорій
- розширено тест analyze_domains_test.sh для перевірки нових параметрів сортування
- оновлено README.md та README.en.md з прикладами використання опцій сортування

## Тип зміни
- feat

## Посилання на задачу/квиток
- #NO-TASK

## Перевірки:
- [x] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив:
- немає впливу на зовнішні API; сумісність не порушено

## Скрін/лог/профіль (за потреби):
- не потребує


------
https://chatgpt.com/codex/tasks/task_e_68fd4cb70838832ebd1fe38fa9b6ed6d