### PR TITLE
Додано дзеркала ClamAV до білого списку

### DIFF
--- a/categories/antivirus.txt
+++ b/categories/antivirus.txt
@@ -1,6 +1,6 @@
 # @description: Антивірусні сервіси — домени для оновлень та перевірки безпеки
 # @author: Команда проєкту whitelist
-# @last_review: 2024-05-01
+# @last_review: 2024-05-27
 
 avast.com
 defs.symantec.com
@@ -13,7 +13,6 @@ update.eset.com
 # Популярні антивіруси
 avira.com
 bitdefender.com
-clamav.net
 downloads.malwarebytes.com
 downloads.sophos.com
 malwarebytes.com
@@ -24,3 +23,15 @@ update.avira.com
 update.pandasecurity.com
 updates.bitdefender.com
 updates.mcafee.com
+
+# ClamAV — оновлення сигнатур і документація (2024-05-27)
+clamav.net                       # офіційний сайт та документація ClamAV
+database.clamav.net              # основний сервер оновлення баз вірусів
+db.us.clamav.net                 # регіональне дзеркало оновлень (США)
+db.ca.clamav.net                 # регіональне дзеркало оновлень (Канада)
+db.fr.clamav.net                 # регіональне дзеркало оновлень (Франція)
+db.de.clamav.net                 # регіональне дзеркало оновлень (Німеччина)
+db.uk.clamav.net                 # регіональне дзеркало оновлень (Велика Британія)
+db.it.clamav.net                 # регіональне дзеркало оновлень (Італія)
+db.jp.clamav.net                 # регіональне дзеркало оновлень (Японія)
+db.hk.clamav.net                 # регіональне дзеркало оновлень (Гонконг)

--- a/categories/comment_allowlist.txt
+++ b/categories/comment_allowlist.txt
@@ -11,7 +11,6 @@ antivirus.txt|repository.eset.com
 antivirus.txt|update.eset.com
 antivirus.txt|avira.com
 antivirus.txt|bitdefender.com
-antivirus.txt|clamav.net
 antivirus.txt|downloads.malwarebytes.com
 antivirus.txt|downloads.sophos.com
 antivirus.txt|malwarebytes.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -237,6 +237,15 @@ ctldl.windowsupdate.com
 cws.conviva.com
 cwtv-mrss-akamai.cwtv.com
 cwtv-prod-elb.digitalsmiths.net
+database.clamav.net
+db.ca.clamav.net
+db.de.clamav.net
+db.fr.clamav.net
+db.hk.clamav.net
+db.it.clamav.net
+db.jp.clamav.net
+db.uk.clamav.net
+db.us.clamav.net
 d2c8v52ll5s99u.cloudfront.net
 d2gatte9o95jao.cloudfront.net
 d83eunklitikj.cloudfront.net


### PR DESCRIPTION
## Опис змін
- додано секцію з коментарями для доменів ClamAV у категорії антивірусів
- додано відповідні домени ClamAV до згенерованого білого списку
- вилучено тимчасовий виняток ClamAV із comment_allowlist

## Тип зміни
- feat

## Посилання на задачу/квиток
- #NO-TASK

## Перевірки:
- [x] юніт-тести додано/оновлено (якщо змінено логіку)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив:
- впливу на API/сумісність/перформанс/міграції немає

## Скрін/лог/профіль (за потреби):
- не потрібно

------
https://chatgpt.com/codex/tasks/task_e_69006cb713a0832eb3a140d12db4cd64