### PR TITLE
Додано домени бренду Nova для Нової пошти

### DIFF
--- a/categories/ukrainian_services.txt
+++ b/categories/ukrainian_services.txt
@@ -15,6 +15,10 @@ novaposhta.ua        # логістична компанія Нова пошта
 api.novaposhta.ua        # API Нової пошти
 my.novaposhta.ua         # особистий кабінет Нової пошти
 tracking.novaposhta.ua   # відстеження відправлень НП
+nova.ua                # новий бренд «Нова»
+api.nova.ua            # API сервісів бренду «Нова»
+my.nova.ua             # особистий кабінет бренду «Нова»
+tracking.nova.ua       # відстеження відправлень бренду «Нова»
 olx.ua               # сервіс оголошень
 oschadbank.ua        # інтернет-банкінг Ощадбанку
 online.oschadbank.ua # вебверсія «Ощад 24/7»

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -104,6 +104,7 @@ api.live.net
 api.micloud.xiaomi.net
 api.monobank.ua
 api.mycrealitycloud.com
+api.nova.ua
 api.novaposhta.ua
 api.openai.com
 api.paymonobank.ua
@@ -885,6 +886,7 @@ mssdk-va.tiktok.com
 mtalk.google.com
 music.youtube.com
 my.adguard.com
+my.nova.ua
 my.novaposhta.ua
 my.ukrposhta.ua
 naurok.ua
@@ -893,6 +895,7 @@ next.privat24.ua
 norton.com
 notify.xboxlive.com
 nous.technology
+nova.ua
 novaposhta.com
 novaposhta.com.ua
 novaposhta.ua
@@ -1120,6 +1123,7 @@ token.cp.microsoft.com
 tokensit.cp.microsoft-tst.com
 track.ukrposhta.ua
 tracking-protection.cdn.mozilla.net
+tracking.nova.ua
 tracking.novaposhta.ua
 trembita.gov.ua
 ttlivecdn.com


### PR DESCRIPTION
## Опис змін
- Додано домени nova.ua та ключові піддомени (api, my, tracking) до категорії українських сервісів для підтримки бренду «Нова».
- Перегенеровано whitelist із врахуванням нових доменів.

## Тип зміни
- feat

## Посилання на задачу
- #NP-1

## Перевірки
- [ ] юніт-тести додано/оновлено (логіка не змінювалася, тести не додавалися)
- [ ] локально пройшли тести та лінтери (pytest не містить тестів; validate_category_metadata.sh сигналізує про наявні відсутні метадані у categories/comment_allowlist.txt)
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- Лише доповнення whitelist доменами бренду «Нова»; API/сумісність/перформанс без змін.

## Скрін/лог/профіль (за потреби)
- не потрібно


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208fcfe99c832e9e6a021459a8767d)