### PR TITLE
Додано відсутні домени OpenAI до білого списку

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -15,7 +15,9 @@ gemini.google.com        # Google Gemini (раніше Bard)
 grok.com                 # Grok від xAI
 huggingface.co           # платформа HuggingFace
 mistral.ai               # генеративні моделі Mistral
+cdn.oaistatic.com        # CDN зі статичними ресурсами ChatGPT
 oaistatic.com            # статичні ресурси для ChatGPT
+oaiusercontent.com       # завантаження та вкладення користувачів ChatGPT
 openai.com               # офіційний сайт OpenAI
 perplexity.ai            # пошук з AI
 poe.com                  # AI-чатботи від Quora

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -317,6 +317,7 @@ cdn.creality.com
 cdn.embedly.com
 cdn.fbsbx.com
 cdn.jsdelivr.net
+cdn.oaistatic.com
 cdn.office.net
 cdn.optimizely.com
 cdn.refersion.com
@@ -1032,6 +1033,7 @@ ntservicepack.microsoft.com
 o1.email.plex.tv
 o2.sg0.plex.tv
 oaistatic.com
+oaiusercontent.com
 oauth.live.com
 oauthaccountmanager.googleapis.com
 ocsp.apple.com


### PR DESCRIPTION
## Опис змін
- Додав cdn.oaistatic.com та oaiusercontent.com до категорії AI-сервісів із поясненнями.
- Розширив whitelist.txt цими доменами, щоб повністю покрити ресурси OpenAI та ChatGPT.

## Тип зміни
- fix

## Посилання на задачу/квиток
- #WL-0

## Перевірки
- [ ] юніт-тести додано/оновлено (зміни даних, логіка не змінювалась)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- На API та сумісність впливу немає; зміни обмежуються whitelist.

## Скрін/лог/профіль (за потреби)
- Не потрібно

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931257f998c832eafa82e2418b072d3)