### PR TITLE
Додано CDN-домени для коректного відображення ChatGPT

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -7,6 +7,7 @@ anthropic.com            # інформація та документація An
 api.openai.com           # API ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
 chat.openai.com          # вебклієнт ChatGPT на домені openai.com
+cdn.openai.com           # CDN зі статичними ресурсами та зображеннями ChatGPT
 claude.ai                # сервіс Claude від Anthropic
 cohere.ai                # сервіс Cohere API
 copilot.microsoft.com    # веб-інтерфейс Microsoft Copilot
@@ -19,6 +20,7 @@ cdn.oaistatic.com        # CDN зі статичними ресурсами Chat
 oaistatic.com            # статичні ресурси для ChatGPT
 oaiusercontent.com       # завантаження та вкладення користувачів ChatGPT
 openai.com               # офіційний сайт OpenAI
+openaicom.imgix.net      # медіафайли та ілюстрації на сторінках ChatGPT
 perplexity.ai            # пошук з AI
 poe.com                  # AI-чатботи від Quora
 platform.openai.com      # веб-інтерфейс OpenAI


### PR DESCRIPTION
## Опис змін
- Додано відсутні домени cdn.openai.com та openaicom.imgix.net до категорії ai_services для повного завантаження візуальних елементів ChatGPT.

## Тип зміни
- fix

## Посилання на задачу/квиток
- #SUPPORT-000

## Перевірки
- [x] юніт-тести додано/оновлено (не потрібно)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

## Вплив
- Без змін API; вплив лише на склад списку доменів.

## Скрін/лог/профіль
- Не потрібно.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936934a12dc832e8bdddca0d7e101b3)