### PR TITLE
feat: додано телеграм-домени до whitelist

### DIFF
--- a/categories/messengers.txt
+++ b/categories/messengers.txt
@@ -5,10 +5,13 @@
 api.telegram.org            # API Telegram
 cdn.telegram.org        # CDN Telegram
 core.telegram.org          # документація Telegram
+t.me                    # короткі посилання на канали та боти Telegram
 discord.com             # чат Discord
 messenger.com           # вебверсія Facebook Messenger
 signal.org              # офіційний сайт Signal із завантаженнями клієнтів
+telegra.ph              # платформа статей Telegraph від Telegram
 telegram.org            # месенджер Telegram
+web.telegram.org        # вебклієнт Telegram
 whatsapp.com            # месенджер WhatsApp
 eyecon-app.com         # телефонна книга Eyecon
 www.eyecon-app.com     # вебінтерфейс Eyecon

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1271,6 +1271,7 @@ sysctl.org
 s{1..5}.symcb.com
 t.co
 t.ly
+t.me
 t0.ssl.ak.dynamic.tiles.virtualearth.net
 t0.ssl.ak.tiles.virtualearth.net
 tawk.to
@@ -1279,6 +1280,7 @@ tbsc.apple.com
 teams.cloudflare.com
 teams.microsoft.com
 tedcdn.com
+telegra.ph
 telegram.org
 textsecure-service-whispersystems.org
 themoviedb.com
@@ -1387,6 +1389,7 @@ warp.cloudflare.com
 warp.cloudflareclient.com
 web.facebook.com
 web.monobank.ua
+web.telegram.org
 weeklyad.target.com
 weeklyad.target.com.edgesuite.net
 wg.gcdn.wargaming.net


### PR DESCRIPTION
**Опис змін:**
- додано t.me, telegra.ph та web.telegram.org до категорії месенджерів із коментарями для прозорості.
- оновлено загальний whitelist для підтримки коротких посилань, вебклієнта та публікацій Telegram.

**Тип зміни:** feat

**Посилання на задачу:** [#NONE]

**Перевірки:**
- [ ] юніт-тести додано/оновлено (за потреби)
- [x] локально пройшли тести та лінтери
- [x] немає секретів/ключів у дифі
- [x] немає неконтрольованих великих видалень без пояснення

**Вплив:** зміни сумісності не потребують; додають нові домени до білого списку для коректної роботи Telegram.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69401307c6ec832e97a074024c5b323b)