### PR TITLE
chore: оновлено домени Google та Microsoft

### DIFF
--- a/categories/google_services.txt
+++ b/categories/google_services.txt
@@ -16,6 +16,7 @@ clients3.google.com
 clients4.google.com
 clients5.google.com
 clients6.google.com
+clientservices.googleapis.com
 connectivitycheck.gstatic.com
 cse.google.com
 dl.google.com
@@ -38,6 +39,7 @@ lh3.googleusercontent.com
 manifest.googlevideo.com
 mtalk.google.com
 oauthaccountmanager.googleapis.com
+oauth2.googleapis.com
 ocsp.pki.goog
 play.googleapis.com
 redirector.googlevideo.com
@@ -46,6 +48,7 @@ redirector.gvt2.com           # завантаження Chrome/Android чере
 reminders-pa.googleapis.com
 safebrowsing.google.com
 safebrowsing.googleapis.com
+fcm.googleapis.com
 storage.googleapis.com        # публічні об’єкти Google Cloud Storage
 time.google.com
 play-lh.googleusercontent.com # іконки та медіа Google Play

--- a/categories/microsoft_updates.txt
+++ b/categories/microsoft_updates.txt
@@ -5,6 +5,7 @@
 assets.onestore.ms
 cdn.office.net
 ctldl.windowsupdate.com
+delivery.mp.microsoft.com
 dl.delivery.mp.microsoft.com
 dns.msftncsi.com
 download.windowsupdate.com
@@ -31,6 +32,7 @@ settings-win.data.microsoft.com
 storeedgefd.dsx.mp.microsoft.com
 teams.microsoft.com
 update.microsoft.com
+windowsupdate.com
 windowsupdate.microsoft.com
 www.msftconnecttest.com
 www.msftncsi.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -325,6 +325,7 @@ clients3.google.com
 clients4.google.com
 clients5.google.com
 clients6.google.com
+clientservices.googleapis.com
 cloud.mycrealitycloud.com
 cloud.nous.technology
 cloudcameraiot.oss-cn-shanghai.aliyuncs.com
@@ -404,6 +405,7 @@ deepseek.com
 deezer.com
 def-vef.xboxlive.com
 defs.symantec.com
+delivery.mp.microsoft.com
 desktop.docker.com
 dev.virtualearth.net
 developers.cloudflare.com
@@ -680,6 +682,7 @@ fb.me
 fba.apple.com
 fbcdn-creative-a.akamaihd.net
 fbcdn.net
+fcm.googleapis.com
 fcs-keys-pub-prod.cdn-apple.com
 fe3.delivery.dsp.mp.microsoft.com.nsatc.net
 finderapi.micloud.xiaomi.net
@@ -956,6 +959,7 @@ ntservicepack.microsoft.com
 oaistatic.com
 oaiusercontent.com
 oauth.live.com
+oauth2.googleapis.com
 oauthaccountmanager.googleapis.com
 ocsp.apple.com
 ocsp.digicert.com
@@ -1248,6 +1252,7 @@ whispersystems-textsecure-attachments.s3-accelerate.amazonaws.com
 widgets.pinterest.com
 wiki.mikrotik.com
 wikipedia.org
+windowsupdate.com
 windowsupdate.microsoft.com
 wise.com
 wkms-public.apple.com


### PR DESCRIPTION
### Motivation
- Додати відсутні домени для критичних сервісів Google і Microsoft, щоб забезпечити коректну роботу клієнтів і оновлень. 
- Перезгенерувати центральний `whitelist.txt` для застосування цих змін у зведеному списку.

### Description
- Додано `clientservices.googleapis.com`, `oauth2.googleapis.com` та `fcm.googleapis.com` до `categories/google_services.txt`.
- Додано `delivery.mp.microsoft.com` та `windowsupdate.com` до `categories/microsoft_updates.txt`.
- Перезгенеровано `whitelist.txt` викликом скрипта `./generate_whitelist.sh`, щоб включити нові записи у фінальний список.

### Testing
- Виконано `./generate_whitelist.sh` і скрипт завершився успішно з повідомленням "Файл whitelist.txt згенеровано".
- Автоматичні перевірки (пошук нових записів через `rg` та вивід фрагментів `whitelist.txt` через `nl`) підтвердили наявність доданих доменів; юніт-тести не запускались, оскільки зміни стосуються лише даних.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fbb8f7010832e862ea134efd8a697)