### PR TITLE
chore: додано rtg-vpn.dmsu.gov.ua до категорії та загального списку [#CHORE-1]

### DIFF
--- a/categories/ukrainian_services.txt
+++ b/categories/ukrainian_services.txt
@@ -81,6 +81,7 @@ poslugy.gov.ua       # єдиний портал державних послуг
 president.gov.ua     # Офіс Президента України
 prozorro.gov.ua      # публічні закупівлі ProZorro
 rada.gov.ua          # Верховна Рада України
+rtg-vpn.dmsu.gov.ua  # VPN-портал Державної міграційної служби України
 zakupki.prom.ua      # електронний майданчик ProZorro Market
 spending.gov.ua      # портал використання публічних коштів
 tax.gov.ua           # Державна податкова служба України

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1038,6 +1038,7 @@ pumb.ua
 push.apple.com
 push.services.mozilla.com
 rada.gov.ua
+rtg-vpn.dmsu.gov.ua
 raiffeisen.ua
 raw.githubusercontent.com
 redd.it


### PR DESCRIPTION
### Motivation
- Додати домен `rtg-vpn.dmsu.gov.ua` для забезпечення доступу до VPN‑порталу Державної міграційної служби та узгодження з категорією українських державних сервісів.

### Description
- Додано рядок `rtg-vpn.dmsu.gov.ua` до файлів `categories/ukrainian_services.txt` та `whitelist.txt`; зміни стосуються лише даних у цих файлах.

### Testing
- Автоматизовані тести не запускалися, оскільки це зміна даних; перед злиттям рекомендовано прогнати CI (форматери/лінтери) щоб переконатися у валідності формату.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c667c77c832eb2de0f4a229adc9e)