### PR TITLE
chore: додати домени Anthropic до ai_services [#WHITELIST-42]

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -1,14 +1,16 @@
 # @description: AI-сервіси — платформи для роботи з ШІ
 # @author: Команда проєкту whitelist
-# @last_review: 2024-05-01
+# @last_review: 2026-03-02
 
 aistudio.google.com      # інтерфейс Google AI Studio
 anthropic.com            # інформація та документація Anthropic
+api.anthropic.com        # API Anthropic для інтеграцій і застосунків
 api.openai.com           # API ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
 chat.openai.com          # вебклієнт ChatGPT на домені openai.com
 cdn.openai.com           # CDN зі статичними ресурсами та зображеннями ChatGPT
 claude.ai                # сервіс Claude від Anthropic
+console.anthropic.com    # консоль керування ключами та налаштуваннями Anthropic
 cohere.ai                # сервіс Cohere API
 copilot.microsoft.com    # веб-інтерфейс Microsoft Copilot
 deepseek.com             # платформа DeepSeek

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -102,6 +102,7 @@ api-mifit.huami.com
 api-school.apple.com
 api-tv.spotify.com
 api.amazfit.com
+api.anthropic.com
 api.apple-cloudkit.com
 api.cloudflareclient.com
 api.directory.signal.org
@@ -363,6 +364,7 @@ connect.facebook.com
 connectivity.cloudflareclient.com
 connectivitycheck.android.com
 connectivitycheck.gstatic.com
+console.anthropic.com
 content.smarttender.biz
 contentproxy.signal.org
 copilot.microsoft.com


### PR DESCRIPTION
### Motivation
- Забезпечити повноцінну роботу сервісів Anthropic/Claude та інтеграцій через API шляхом додавання відсутніх хостів у категорію AI.

### Description
- Додано `api.anthropic.com` і `console.anthropic.com` у `categories/ai_services.txt` та оновлено `# @last_review` до `2026-03-02`, після чого перегенеровано комбінований `whitelist.txt` (зміни у `categories/ai_services.txt` і `whitelist.txt`).

### Testing
- Виконано `./generate_whitelist.sh` та інтеграційний тест `bash tests/generate_whitelist_test.sh`, обидва успішні; також запущено `./check_category_comments.sh`, який виявив існуючі зауваження в інших категоріях (не пов'язані з цим PR), і `./check_duplicates.sh`, який підтвердив відсутність дублікатів у `whitelist.txt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5762c10b4832eb50ecd224dcdee2e)