### PR TITLE
Add OpenAI auth and file hosts to AI services

### DIFF
--- a/categories/ai_services.txt
+++ b/categories/ai_services.txt
@@ -6,6 +6,7 @@ aistudio.google.com      # інтерфейс Google AI Studio
 anthropic.com            # інформація та документація Anthropic
 api.anthropic.com        # API Anthropic для інтеграцій і застосунків
 api.openai.com           # API ChatGPT
+auth.openai.com          # авторизація OpenAI/ChatGPT
 chatgpt.com              # веб-інтерфейс ChatGPT
 chat.openai.com          # вебклієнт ChatGPT на домені openai.com
 cdn.openai.com           # CDN зі статичними ресурсами та зображеннями ChatGPT
@@ -21,6 +22,7 @@ mistral.ai               # генеративні моделі Mistral
 cdn.oaistatic.com        # CDN зі статичними ресурсами ChatGPT
 oaistatic.com            # статичні ресурси для ChatGPT
 oaiusercontent.com       # завантаження та вкладення користувачів ChatGPT
+files.oaiusercontent.com # доступ до файлів і вкладень у ChatGPT
 openai.com               # офіційний сайт OpenAI
 openaicom.imgix.net      # медіафайли та ілюстрації на сторінках ChatGPT
 perplexity.ai            # пошук з AI

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -261,6 +261,7 @@ assets.onestore.ms
 attestation.xboxlive.com
 audiocontentdownload.apple.com
 auth.docker.io
+auth.openai.com
 auto.ria.com
 avast.com
 avira.com
@@ -675,7 +676,6 @@ external-lhr7-1.xx.fbcdn.net
 external-lhr8-1.xx.fbcdn.net
 external-lhr9-1.xx.fbcdn.net
 external-ort2-1.xx.fbcdn.net
-external.example
 eyecon-app.com
 fabric.io
 facebook.com
@@ -689,6 +689,7 @@ fbcdn.net
 fcm.googleapis.com
 fcs-keys-pub-prod.cdn-apple.com
 fe3.delivery.dsp.mp.microsoft.com.nsatc.net
+files.oaiusercontent.com
 finderapi.micloud.xiaomi.net
 firestore.googleapis.com
 fonts.googleapis.com


### PR DESCRIPTION
### Motivation
- Ensure ChatGPT/OpenAI clients function correctly by whitelisting the service authorization endpoint and the host used for file attachments.

### Description
- Added `auth.openai.com` and `files.oaiusercontent.com` to `categories/ai_services.txt`.
- Regenerated the combined `whitelist.txt` so the new hosts are included in the final export.
- Changes committed and prepared as a minimal feature update without added secrets or behavioral changes.

### Testing
- Ran `./generate_whitelist.sh` which completed successfully and produced an updated `whitelist.txt`.
- Ran `./check_category_comments.sh` which failed, but the failures are unrelated to this change and concern existing entries in `google_services.txt` and `microsoft_updates.txt`.
- Verified the new hosts are present in both `categories/ai_services.txt` and `whitelist.txt` using `rg -n "auth.openai.com|files.oaiusercontent.com"` and confirmed the commit with `git status`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade3527ba8832e95548c20ab0f40e0)