### PR TITLE
Add notifications.googleapis.com to Google services allowlist

### DIFF
--- a/categories/google_services.txt
+++ b/categories/google_services.txt
@@ -49,6 +49,7 @@ reminders-pa.googleapis.com
 safebrowsing.google.com
 safebrowsing.googleapis.com
 fcm.googleapis.com
+notifications.googleapis.com
 storage.googleapis.com        # публічні об’єкти Google Cloud Storage
 time.google.com
 play-lh.googleusercontent.com # іконки та медіа Google Play


### PR DESCRIPTION
### Motivation
- Allow Google Notifications API/push endpoints by adding `notifications.googleapis.com` to the Google services allowlist.

### Description
- Inserted `notifications.googleapis.com` into `categories/google_services.txt` alongside other Google API domains.

### Testing
- Verified presence with `rg -n "^notifications\.googleapis\.com$" categories/google_services.txt` and confirmed the line exists; ran `./check_duplicates.sh` and confirmed no duplicate entry was reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6994240a0832eb8ce72b8839c7b8f)