### PR TITLE
Fix service category file handling

### DIFF
--- a/.github/workflows/duplicate_check.yml
+++ b/.github/workflows/duplicate_check.yml
@@ -11,7 +11,11 @@ jobs:
   duplicates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Встановити залежності
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dnsutils
       - name: Виконати перевірку
         run: |
           chmod +x ./check_duplicates.sh

--- a/check_duplicates.sh
+++ b/check_duplicates.sh
@@ -10,6 +10,19 @@ case "${SKIP_DNS_CHECK:-0}" in
     ;;
 esac
 
+is_service_category_file() {
+  local name
+  name="$(basename "$1")"
+  case "$name" in
+    comment_allowlist.txt|deprecated.txt)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 if (( ! skip_dns_check )); then
   if command -v host >/dev/null 2>&1; then
     lookup_cmd=(host -W1)
@@ -28,6 +41,11 @@ check_file() {
     return 1
   fi
 
+  if is_service_category_file "$file"; then
+    echo "Службовий файл пропущено: $file"
+    return 0
+  fi
+
   local dup
   local invalid=0
   # Видаляємо коментарі, щоб дублікати шукалися лише за доменами
@@ -35,6 +53,7 @@ check_file() {
     | sed '/^\s*$/d' \
     | cut -d '#' -f1 \
     | awk '{print $1}' \
+    | sed '/^$/d' \
     | sort \
     | uniq -d)
   if [ -n "$dup" ]; then
@@ -52,13 +71,15 @@ check_file() {
         echo "Недоступний домен: $host" >&2
         invalid=1
       fi
-    done < <(grep -v '^\s*#' "$file" | sed '/^\s*$/d' | awk '{print $1}' | sed 's/^\*\.//')
+    done < <(grep -v '^\s*#' "$file" | sed '/^\s*$/d' | cut -d '#' -f1 | awk '{print $1}' | sed 's/^\*\.//' | sed '/^$/d')
   fi
 
   if (( invalid )); then
     return 1
   fi
 }
+
+shopt -s nullglob
 
 if [ "$#" -eq 0 ]; then
   set -- whitelist.txt categories/*.txt

--- a/generate_whitelist.sh
+++ b/generate_whitelist.sh
@@ -28,6 +28,19 @@ all files inside categories/ will be processed.
 EOF
 }
 
+is_service_category_file() {
+  local name
+  name="$(basename "$1")"
+  case "$name" in
+    comment_allowlist.txt|deprecated.txt)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 args=()
 
 while [ "$#" -gt 0 ]; do
@@ -97,10 +110,12 @@ if [ "$INCLUDE_EXTERNAL_SOURCES" = "1" ] && [ -f "$SOURCES_COMBINED" ]; then
   files+=("$SOURCES_COMBINED")
 fi
 
-# Виключити службові файли категорій
+# Виключити службові файли категорій, які не є джерелами доменів для whitelist.
 filtered_files=()
 for f in "${files[@]}"; do
-  [ "$(basename "$f")" = "comment_allowlist.txt" ] && continue
+  if is_service_category_file "$f"; then
+    continue
+  fi
   filtered_files+=("$f")
 done
 files=("${filtered_files[@]}")

--- a/regenerate_whitelist.py
+++ b/regenerate_whitelist.py
@@ -7,6 +7,7 @@ import glob
 script_dir = os.path.dirname(os.path.abspath(__file__))
 categories_dir = os.path.join(script_dir, "categories")
 whitelist_path = os.path.join(script_dir, "whitelist.txt")
+service_category_files = {"comment_allowlist.txt", "deprecated.txt"}
 
 include_external = os.environ.get("INCLUDE_EXTERNAL_SOURCES", "1") == "1"
 sources_combined = os.environ.get("SOURCES_COMBINED", os.path.join(script_dir, "sources", "generated", "all_sources.txt"))
@@ -15,7 +16,7 @@ domains = set()
 
 files = sorted(glob.glob(os.path.join(categories_dir, "*.txt")))
 for filepath in files:
-    if os.path.basename(filepath) == "comment_allowlist.txt":
+    if os.path.basename(filepath) in service_category_files:
         continue
     with open(filepath, "r", encoding="utf-8") as fh:
         for line in fh:
@@ -32,12 +33,13 @@ if include_external and sources_combined and os.path.isfile(sources_combined):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            if line:
-                domains.add(line)
+            domain = line.split("#")[0].strip()
+            if domain:
+                domains.add(domain)
 
 with open(whitelist_path, "w", encoding="utf-8") as f:
     f.write("# Автоматично згенеровано скриптом generate_whitelist.sh\n")
-    for domain in sorted(domains, key=lambda x: x.lower()):
+    for domain in sorted(domains):
         f.write(domain + "\n")
 
 print(f"Файл {whitelist_path} згенеровано з {len(domains)} доменів")

--- a/sort_categories.sh
+++ b/sort_categories.sh
@@ -6,8 +6,23 @@ set -euo pipefail
 dir=${1:-categories}
 shopt -s nullglob
 
+is_service_category_file() {
+  local name
+  name="$(basename "$1")"
+  case "$name" in
+    comment_allowlist.txt|deprecated.txt)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 for file in "$dir"/*.txt; do
-  [ "$(basename "$file")" = "deprecated.txt" ] && continue
+  if is_service_category_file "$file"; then
+    continue
+  fi
 
   mapfile -t lines < "$file"
   header=()

--- a/tests/check_duplicates_test.sh
+++ b/tests/check_duplicates_test.sh
@@ -57,6 +57,21 @@ if ! SKIP_DNS_CHECK=yes ./check_duplicates.sh "$tmpdir/list.txt" >/dev/null 2>&1
   exit 1
 fi
 
+mkdir -p "$tmpdir/categories"
+echo 'bad.invalid # category:test.txt' > "$tmpdir/categories/deprecated.txt"
+echo 'test.txt|bad.invalid' > "$tmpdir/categories/comment_allowlist.txt"
+: > "$HOST_LOG"
+
+if ! ./check_duplicates.sh "$tmpdir/categories" >/dev/null 2>&1; then
+  echo "Службові файли категорій не повинні спричиняти помилку перевірки" >&2
+  exit 1
+fi
+
+if [[ -s "$HOST_LOG" ]]; then
+  echo "DNS перевірка не повинна запускатись для службових файлів" >&2
+  exit 1
+fi
+
 empty_file="$tmpdir/empty.txt"
 : > "$empty_file"
 

--- a/tests/generate_whitelist_test.sh
+++ b/tests/generate_whitelist_test.sh
@@ -28,6 +28,24 @@ rm -f whitelist.txt
 grep -q '^example.com' whitelist.txt
 rm -r categories/_tmpdir
 
+# Перевірка виключення службових файлів категорій
+mkdir -p categories/_tmp_service
+echo "included.example" > categories/_tmp_service/regular.txt
+echo "deprecated.example # category:regular.txt" > categories/_tmp_service/deprecated.txt
+rm -f whitelist.txt
+./generate_whitelist.sh categories/_tmp_service >/dev/null
+if ! grep -q '^included.example$' whitelist.txt; then
+  echo "Звичайний файл категорії не потрапив до whitelist" >&2
+  rm -r categories/_tmp_service
+  exit 1
+fi
+if grep -q '^deprecated.example$' whitelist.txt; then
+  echo "Службовий deprecated.txt не повинен потрапляти до whitelist" >&2
+  rm -r categories/_tmp_service
+  exit 1
+fi
+rm -r categories/_tmp_service
+
 # Перевірка видалення коментарів та дублювання доменів
 cat <<'EOF' > categories/_tmp_comments.txt
 example.com # перший

--- a/tests/whitelist_builder_api_test.sh
+++ b/tests/whitelist_builder_api_test.sh
@@ -64,8 +64,13 @@ import json, os
 payload = json.loads(os.environ["CATEGORIES_PAYLOAD"])
 if payload.get("status") != "ok":
     raise SystemExit("Некоректна відповідь /api/categories")
-if not payload.get("categories"):
+categories = payload.get("categories") or []
+if not categories:
     raise SystemExit("Перелік категорій порожній")
+names = {item.get("name") for item in categories}
+for service_name in {"comment_allowlist.txt", "deprecated.txt"}:
+    if service_name in names:
+        raise SystemExit(f"Службовий файл {service_name} не повинен повертатись як категорія")
 PY
 
 response=$(curl -fs -X POST "http://127.0.0.1:$port/api/build" \
@@ -95,6 +100,14 @@ file_path="$tmpdir/output/$file_name"
 
 if [[ ! -s "$file_path" ]]; then
   echo "Згенерований файл не знайдено" >&2
+  exit 1
+fi
+
+if curl -fs -X POST "http://127.0.0.1:$port/api/build" \
+  -H "Authorization: Bearer $api_token" \
+  -H 'Content-Type: application/json' \
+  -d '{"categories":["comment_allowlist.txt"],"include_external":false}' >/dev/null; then
+  echo "Службовий comment_allowlist.txt не повинен прийматись як категорія" >&2
   exit 1
 fi
 

--- a/whitelist_builder_api.py
+++ b/whitelist_builder_api.py
@@ -26,6 +26,7 @@ class CategoryInfo:
 
 
 ROOT = pathlib.Path(__file__).resolve().parent
+SERVICE_CATEGORY_FILES = {"comment_allowlist.txt", "deprecated.txt"}
 
 
 def _read_json(handler: BaseHTTPRequestHandler) -> Any:
@@ -50,6 +51,10 @@ def _safe_join(base: pathlib.Path, *parts: str) -> pathlib.Path:
     return candidate
 
 
+def _is_service_category_file(path: pathlib.Path) -> bool:
+    return path.name in SERVICE_CATEGORY_FILES
+
+
 def _count_domains(path: pathlib.Path) -> int:
     count = 0
     with path.open("r", encoding="utf-8") as fh:
@@ -67,7 +72,6 @@ def _append_log(path: pathlib.Path, message: str) -> None:
         fh.write(f"{timestamp}\t{message}\n")
 
 
-
 class BuilderConfig:
     """Налаштування сервера."""
 
@@ -76,7 +80,7 @@ class BuilderConfig:
         if not self.categories_dir.exists():
             return items
         for path in sorted(self.categories_dir.glob("*.txt")):
-            if path.name == "deprecated.txt":
+            if _is_service_category_file(path):
                 continue
             count = _count_domains(path)
             description = self._extract_description(path)
@@ -132,6 +136,8 @@ class BuilderConfig:
             candidate = _safe_join(self.categories_dir, value)
         if not candidate.exists():
             raise ValueError(f"Категорію {value} не знайдено")
+        if candidate.parent == self.categories_dir and _is_service_category_file(candidate):
+            raise ValueError(f"Службовий файл {candidate.name} не можна використовувати як категорію")
         return candidate
 
     def resolve_extra(self, value: str) -> pathlib.Path:
@@ -143,7 +149,6 @@ class BuilderConfig:
             if not allowed:
                 raise ValueError("Шлях не входить до списку дозволених extra-path")
         return candidate
-
 
 
 class BuilderHTTPServer(ThreadingHTTPServer):


### PR DESCRIPTION
Fixes service category file handling.

Changes:
- exclude comment_allowlist.txt and deprecated.txt from whitelist generation;
- align Python regeneration with Bash generation;
- skip service files in duplicate checks and sorting;
- hide service files from the builder API;
- install dnsutils in duplicate_check workflow;
- add regression tests for these cases.

Note: changes are isolated in branch fix/service-files-handling.