### PR TITLE
perf: bound parallel DNS checks

### DIFF
--- a/check_duplicates.sh
+++ b/check_duplicates.sh
@@ -26,6 +26,12 @@ is_service_category_file() {
 }
 
 if (( ! skip_dns_check )); then
+  dns_parallelism="${DNS_PARALLELISM:-8}"
+  if ! [[ "$dns_parallelism" =~ ^[1-9][0-9]*$ ]]; then
+    echo "DNS_PARALLELISM має бути додатним цілим числом" >&2
+    exit 1
+  fi
+
   if command -v host >/dev/null 2>&1; then
     lookup_cmd=(host -W1)
   elif command -v nslookup >/dev/null 2>&1; then
@@ -67,16 +73,42 @@ check_file() {
   fi
 
   if (( ! skip_dns_check )); then
+    local dns_failures_dir
+    dns_failures_dir=$(mktemp -d)
+    local -a dns_pids=()
+
     while read -r host; do
       [[ -z "$host" ]] && continue
       # Для wildcard не перевіряємо apex/base domain: такий тест дає систематичні false-positive.
       [[ "$host" == \*.* ]] && continue
-      if ! "${lookup_cmd[@]}" "$host" 2>&1 |
-        grep -Eq '([0-9]{1,3}\.){3}[0-9]{1,3}|([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}'; then
-        echo "Недоступний домен: $host" >&2
-        invalid=1
+
+      (
+        if ! "${lookup_cmd[@]}" "$host" 2>&1 |
+          grep -Eq '([0-9]{1,3}\.){3}[0-9]{1,3}|([0-9a-fA-F]{1,4}:){1,7}[0-9a-fA-F]{1,4}'; then
+          printf '%s\n' "$host" > "$dns_failures_dir/$BASHPID"
+        fi
+      ) &
+      dns_pids+=("$!")
+
+      if (( ${#dns_pids[@]} >= dns_parallelism )); then
+        for pid in "${dns_pids[@]}"; do
+          wait "$pid" || true
+        done
+        dns_pids=()
       fi
     done < <(grep -v '^\s*#' "$file" | sed '/^\s*$/d' | cut -d '#' -f1 | awk '{print $1}' | sed '/^$/d')
+
+    for pid in "${dns_pids[@]}"; do
+      wait "$pid" || true
+    done
+
+    if compgen -G "$dns_failures_dir/*" >/dev/null; then
+      while read -r host; do
+        echo "Недоступний домен: $host" >&2
+        invalid=1
+      done < <(cat "$dns_failures_dir"/* | LC_ALL=C sort -u)
+    fi
+    rm -rf "$dns_failures_dir"
   fi
 
   if (( invalid )); then

--- a/tests/check_duplicates_test.sh
+++ b/tests/check_duplicates_test.sh
@@ -11,19 +11,36 @@ bad.invalid
 LIST
 
 HOST_LOG="$tmpdir/host_calls.log"
-export HOST_LOG
+BARRIER_DIR="$tmpdir/barrier"
+export HOST_LOG BARRIER_DIR
 
 cat <<'HOST' > "$tmpdir/host"
 #!/usr/bin/env bash
 echo "$@" >> "$HOST_LOG"
 domain="${@: -1}"
-if [[ "$domain" == "good.com" ]]; then
-  echo "good.com has address 1.2.3.4"
-  exit 0
-else
-  echo "Host $domain not found" >&2
-  exit 1
-fi
+case "$domain" in
+  good.com)
+    echo "good.com has address 1.2.3.4"
+    exit 0
+    ;;
+  parallel1.example|parallel2.example)
+    mkdir -p "$BARRIER_DIR"
+    touch "$BARRIER_DIR/$domain"
+    for _ in $(seq 1 20); do
+      if [[ -f "$BARRIER_DIR/parallel1.example" && -f "$BARRIER_DIR/parallel2.example" ]]; then
+        echo "$domain has address 1.2.3.4"
+        exit 0
+      fi
+      sleep 0.05
+    done
+    echo "Host $domain timed out waiting for concurrent lookup" >&2
+    exit 1
+    ;;
+  *)
+    echo "Host $domain not found" >&2
+    exit 1
+    ;;
+esac
 HOST
 chmod +x "$tmpdir/host"
 
@@ -60,6 +77,18 @@ fi
 
 if ! SKIP_DNS_CHECK=yes ./check_duplicates.sh "$tmpdir/list.txt" >/dev/null 2>&1; then
   echo "Скрипт має приймати значення yes у SKIP_DNS_CHECK" >&2
+  exit 1
+fi
+
+cat <<'PARALLEL' > "$tmpdir/parallel.txt"
+parallel1.example
+parallel2.example
+PARALLEL
+rm -rf "$BARRIER_DIR"
+mkdir -p "$BARRIER_DIR"
+
+if ! DNS_PARALLELISM=2 ./check_duplicates.sh "$tmpdir/parallel.txt" >/dev/null 2>&1; then
+  echo "DNS перевірки мають виконуватись паралельно при DNS_PARALLELISM=2" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Мета
Прискорити advisory DNS-перевірку без зміни її семантики.

## Зміни
- exact-domain DNS lookups виконуються bounded-паралельно;
- `DNS_PARALLELISM` задає максимальну кількість одночасних lookup (default: `8`);
- wildcard entries як і раніше не DNS-resolve'яться;
- `SKIP_DNS_CHECK` збережено без змін;
- failures збираються окремо й повертаються через чинний exit status/output.

## TDD / перевірка
- RED: test-only commit `2d3c9b2…` закономірно впав на послідовній реалізації;
- GREEN: commit `f459f77…` — branch CI success, усі test scripts + stats freshness success.

## Scope
Лише `check_duplicates.sh` і `tests/check_duplicates_test.sh`. Старий draft PR #127 закрито як superseded; цей PR переносить тільки актуальну частину поверх поточного `main`.

## Ризик
Низький. При `DNS_PARALLELISM=1` поведінка фактично серійна; default `8` лише скорочує час weekly DNS-check.